### PR TITLE
Kernelize local-first execution policy

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -12,6 +12,7 @@ layers:
     - project_local_canon
     - prd_first_execution
     - research_policy
+    - execution_surface_policy
     - github_issue_tree
     - automatic_bug_intake
     - github_delivery_flow
@@ -69,6 +70,23 @@ research_policy:
     - distinguish_verified_facts_from_assumptions
     - if_known_url_exists_fetch_it_directly_instead_of_re-searching_blindly
     - if_primary_tool_is_unavailable_record_the_gap_and_use_the_best_documented_fallback
+
+execution_surface_policy:
+  default_surface:
+    - local_operator_machine
+    - self_hosted_runner_when_project_already_has_one
+  github_actions_are_for:
+    - repository_native_automation
+    - scheduled_workflows
+    - deploy_pipelines
+    - hosted_verification_that_requires_repository_runtime
+    - event_driven_jobs_that_should_run_without_an_operator_terminal
+  rules:
+    - do_not_default_to_paid_github_hosted_actions_for_ordinary_development_work
+    - if_work_can_run_locally_prefer_local_execution_first
+    - detect_local_prerequisites_before_work_starts
+    - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
+    - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
 
 github_issue_tree:
   parent: Epic

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This repository is the standalone source-of-truth for:
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 
+Execution-surface canon:
+
+- ordinary engineering work should default to the local operator machine first
+- self-hosted runners are preferred over paid GitHub-hosted Actions when the repository already has them
+- GitHub Actions remain for repo-native automation, schedules, deploys, and hosted checks that actually belong there
+
 ## Core idea
 
 Use one shared engineering process across agent families.
@@ -63,6 +69,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how to materialize the kernel into a project
 - [references/MODEL_ADAPTERS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/MODEL_ADAPTERS.md)
   - model adapter policy
+- [references/EXECUTION_SURFACES.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/EXECUTION_SURFACES.md)
+  - local-first versus GitHub Actions execution policy
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
   - how branch/PR/merge flow should work end-to-end
 - [references/BUG_INTAKE.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/BUG_INTAKE.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,7 @@ Read [ENGINEERING_KERNEL.yaml](ENGINEERING_KERNEL.yaml) for the machine-readable
 Read [references/BOOTSTRAP.md](references/BOOTSTRAP.md) when you need to materialize the kernel into a project.
 Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user asks how the kernel should map across GPT/Codex and Claude-style agents.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
+Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/GITHUB_DELIVERY.md](references/GITHUB_DELIVERY.md) when the user asks how branch/PR/merge flow should work end-to-end.
 Read [references/BUG_INTAKE.md](references/BUG_INTAKE.md) when the user asks how runtime failures should become GitHub `Bug` issues without noisy duplication.
 
@@ -28,6 +29,7 @@ The bug-intake rule is explicit:
 - establishing GitHub `Epic / Task / Bug` workflow
 - establishing automatic deduplicated GitHub bug intake
 - establishing Tavily-first research behavior
+- establishing local-first execution and prerequisite bootstrap
 - establishing branch / draft PR / merge discipline
 - creating project-local canon files and templates
 - creating repo-managed GitHub metadata and community-health files
@@ -52,6 +54,7 @@ The bug-intake rule is explicit:
 - project canon
 - PRD-first execution
 - issue tree
+- local-first execution surface
 - PR verification contract
 - ownership and labels
 - research policy

--- a/docs/local-first-execution-policy-prd-2026-04-17.md
+++ b/docs/local-first-execution-policy-prd-2026-04-17.md
@@ -1,0 +1,198 @@
+# PRD: Local-First Execution Surface Policy
+
+Date: `2026-04-17`
+
+Status: `active`
+
+## 1. Problem
+
+The kernel currently defines workflow, GitHub decomposition, verification, and
+bug-intake canon, but it does not explicitly define the preferred execution
+surface for ordinary engineering work.
+
+That leaves a gap:
+
+- agents may default to GitHub-hosted Actions even when the same work can be
+  executed locally
+- teams may spend paid hosted-runner minutes for development, research, and
+  verification that belong on an operator machine or self-hosted runner
+- new repositories do not inherit a clear rule for prerequisite detection and
+  local bootstrap before work begins
+
+## 2. Reconciled Current State
+
+### 2.1 Kernel today
+
+Current kernel already covers:
+
+- PRD-first execution
+- GitHub `Epic / Task / Bug`
+- automatic bug-intake canon
+- bootstrap templates
+- labels and GitHub delivery flow
+
+It does **not** yet say explicitly:
+
+- local machine is the default execution surface for ordinary development
+- self-hosted/local execution should be preferred before paid hosted Actions
+- agents must check/bootstrap prerequisites locally before assuming CI is the
+  place to run work
+
+### 2.2 Official platform contract
+
+Official GitHub docs confirm:
+
+- GitHub-hosted runners in private repositories consume included/billed Actions
+  minutes
+- self-hosted runners are free from GitHub Actions minute billing
+- self-hosted runners are intended for custom environments and repo-controlled
+  execution
+
+Sources:
+
+- `docs.github.com/.../managing-billing-for-github-actions`
+- `docs.github.com/.../about-self-hosted-runners`
+
+### 2.3 Policy implication
+
+The kernel should not teach agents to default to GitHub-hosted Actions for
+ordinary engineering work when:
+
+- the same work can be done locally
+- the operator machine can install prerequisites deterministically
+- a self-hosted runner or local machine is the canonical dev/test surface
+
+At the same time, the kernel should not ban GitHub Actions.
+
+GitHub Actions remain the right surface for:
+
+- repository-native automation
+- scheduled workflows
+- deploy pipelines
+- hosted verification that must execute inside the repository platform
+- event-driven automation that should run without an operator terminal
+
+## 3. Target State
+
+Add a kernel-wide `local-first execution surface` policy.
+
+### 3.1 Default rule
+
+For ordinary development, debugging, research, and verification:
+
+- prefer the local operator machine first
+- if the repository has self-hosted runners, prefer them over paid hosted
+  runners for recurring execution
+
+### 3.2 Required bootstrap rule
+
+Before serious work starts, the agent should:
+
+1. detect the local execution prerequisites
+2. install/bootstrap missing prerequisites deterministically if the repository
+   already defines that path
+3. only escalate to GitHub Actions when local execution is not the right
+   surface
+
+### 3.3 Actions rule
+
+GitHub Actions should be treated as:
+
+- repository automation
+- schedule/event runtime
+- deployment or hosted verification surface
+
+Not as the default place to run ordinary engineering work that could be executed
+locally.
+
+## 4. Write Scope
+
+- `ENGINEERING_KERNEL.yaml`
+- `SKILL.md`
+- `README.md`
+- `references/BOOTSTRAP.md`
+- `references/GITHUB_DELIVERY.md`
+- `templates/project/README.md`
+- `templates/project/AGENTS.md`
+- `templates/project/CONTRIBUTING.md`
+- `tests/test_repo_kernel_canon.py`
+- `tests/test_bootstrap_project_kernel.py`
+
+## 5. Rollout
+
+### Phase 1: Add the policy to the kernel core
+
+Entry condition:
+
+- PRD is active
+
+Changes:
+
+- add machine-readable execution-surface policy
+- add human-readable explanation in kernel docs
+
+Validation:
+
+- kernel docs/tests remain coherent
+
+Success:
+
+- the kernel expresses local-first execution clearly and durably
+
+Rollback trigger:
+
+- policy text becomes contradictory with the existing GitHub delivery layer
+
+### Phase 2: Materialize the policy in project bootstrap
+
+Entry condition:
+
+- core policy exists in kernel docs
+
+Changes:
+
+- update project templates so newly bootstrapped repos inherit local-first
+  execution canon
+
+Validation:
+
+- bootstrap output contains local-first execution guidance
+
+Success:
+
+- a new repo no longer depends on chat memory to inherit the policy
+
+Rollback trigger:
+
+- bootstrap output omits or weakens the rule
+
+## 6. Verification Matrix
+
+Code-path tests:
+
+- `tests/test_repo_kernel_canon.py`
+- `tests/test_bootstrap_project_kernel.py`
+
+Build/runtime checks:
+
+- `.venv/bin/python -m unittest discover -s tests`
+
+Sync checks:
+
+- bootstrap apply on a clean target includes local-first execution text in
+  generated canon files
+
+Live acceptance:
+
+- kernel repo pushed to GitHub
+- skill consumers can read the updated kernel and bootstrap a repo without chat
+  re-explanation
+
+## 7. Acceptance
+
+This slice is closed only when:
+
+- kernel machine-readable core contains explicit local-first execution policy
+- human-readable docs align with that policy
+- project templates inherit the policy
+- tests and bootstrap verification are green

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -8,6 +8,7 @@ Use this file when applying the kernel to a new repository.
 2. Decide whether the project already has stronger local rules.
 3. Install the minimal core first.
 4. Document the maximum GitHub layer separately if settings or plan limits block enforcement.
+5. Record the canonical execution surface and local bootstrap path before normal work begins.
 
 ## Minimal bootstrap outputs
 
@@ -27,6 +28,14 @@ Write or update:
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
 - one active PRD / decision doc
+
+The bootstrapped canon should also make explicit:
+
+- canonical local bootstrap command
+- canonical local verifier/test commands
+- whether the repo uses self-hosted runners
+- which workflows must stay in GitHub Actions
+- that routine development and verification should not default to paid GitHub-hosted Actions
 
 ## How to use the templates
 

--- a/references/BUG_INTAKE.md
+++ b/references/BUG_INTAKE.md
@@ -75,6 +75,16 @@ Automatic or semi-automatic bug issues should include:
 - current evidence
 - containment / rollback status
 
+## Target repository rule
+
+Automatic bug intake belongs in the repository that owns the runtime or workflow
+being observed.
+
+That means:
+
+- project/runtime incidents land in the target project repo
+- the kernel repo stores the canon, not the target project's live bug backlog
+
 ## Fix flow
 
 - create or update the `Bug` intake issue

--- a/references/EXECUTION_SURFACES.md
+++ b/references/EXECUTION_SURFACES.md
@@ -1,0 +1,65 @@
+# Execution Surfaces
+
+Use this when the question is not only *what* the workflow is, but *where* it
+should run.
+
+## Canon
+
+Default to the cheapest correct execution surface.
+
+For ordinary engineering work, that usually means:
+
+- the local operator machine first
+- a self-hosted runner next, if the repository already has one
+
+Do **not** default to paid GitHub-hosted Actions for work that can be executed
+locally.
+
+## Local-first rule
+
+For normal development, debugging, research, verification, and bootstrap:
+
+1. inspect the local prerequisites
+2. use the repository's local bootstrap path if it already exists
+3. install or repair missing local prerequisites deterministically
+4. only escalate to GitHub Actions when local execution is not the right surface
+
+Examples of good local-first work:
+
+- running unit tests
+- running project verification scripts
+- local bootstrap / dependency install
+- documentation generation
+- research and code audit
+- dry-run sync scripts
+
+## When GitHub Actions are the right surface
+
+Use GitHub Actions when the value is specifically repository-native automation:
+
+- scheduled workflows
+- event-driven automation
+- deployment pipelines
+- hosted verification that must execute inside GitHub
+- branch/merge policy checks that belong to the repository platform
+
+## Why this matters
+
+For private repositories, GitHub-hosted Actions consume billed/included runner
+minutes. Self-hosted runners do not consume those GitHub-hosted minutes.
+
+So the kernel rule is:
+
+- local/self-hosted first for ordinary work
+- GitHub Actions for automation that genuinely belongs there
+
+## What to encode in project canon
+
+Project-local canon should state:
+
+- the canonical local bootstrap command
+- the canonical local test/verifier commands
+- whether the project has self-hosted runners
+- which workflows must remain in GitHub Actions
+- that agents should not route routine dev/test work to paid hosted Actions by
+  default

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -2,6 +2,12 @@
 
 Use this when the user wants the full branch / PR / merge discipline, not just issue templates.
 
+Execution-surface rule:
+
+- GitHub delivery flow does not mean GitHub-hosted Actions are the default place to do ordinary engineering work
+- local operator execution or self-hosted runners stay primary for normal dev/test/bootstrap work
+- GitHub Actions are for repository-native automation, scheduled/event jobs, deploys, and hosted verification that must live in the platform
+
 ## Canonical sequence
 
 1. Create or update the PRD

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -18,6 +18,14 @@ This repository follows the agent engineering kernel.
 - if a known URL already exists, fetch/index it directly instead of re-running broad search
 - distinguish verified facts from assumptions
 
+## Execution surface canon
+
+- prefer the local operator machine first for ordinary development, debugging, research, and verification
+- if the project already has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- check local prerequisites before work starts
+- if the repo defines a local bootstrap path, use or repair it before escalating elsewhere
+- use GitHub Actions for repository-native automation, schedules, deploys, and hosted verification that genuinely belongs there
+
 ## GitHub workflow canon
 
 - non-trivial work starts from a parent GitHub issue

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -9,6 +9,13 @@ This repository uses a PRD-first and issue-first engineering workflow.
 - known URLs should be fetched/indexed directly when available
 - verified facts must be separated from assumptions
 
+## Execution surface policy
+
+- use the local machine first for ordinary development, debugging, research, and verification
+- if the repository already has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- check or bootstrap local prerequisites before assuming CI is the right place to run the work
+- keep GitHub Actions for repository-native automation, schedules, deploys, and hosted checks that genuinely need the platform
+
 ## Start from the correct issue
 
 Use:

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -11,6 +11,9 @@ This repository follows the agent engineering kernel.
   - `Task`
   - `Bug`
 - runtime bugs come from verifier/watchdog/runtime-gate fingerprints, not raw logs or chat alerts
+- ordinary development, debugging, and verification should run locally first
+- if the project has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
 - PR closes the leaf issue only
 
 ## Canon files

--- a/tests/test_bootstrap_project_kernel.py
+++ b/tests/test_bootstrap_project_kernel.py
@@ -55,6 +55,9 @@ class BootstrapProjectKernelTests(unittest.TestCase):
             self.assertTrue((target / "scripts" / "sync_github_labels.py").exists())
             self.assertIn("fingerprint", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("raw logs", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("local operator machine", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("GitHub Actions", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("paid GitHub-hosted Actions", (target / "CONTRIBUTING.md").read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -23,6 +23,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "scripts/sync_github_labels.py",
             "references/BOOTSTRAP.md",
             "references/BUG_INTAKE.md",
+            "references/EXECUTION_SURFACES.md",
             "references/MODEL_ADAPTERS.md",
             "references/RESEARCH_POLICY.md",
             "references/GITHUB_DELIVERY.md",
@@ -36,6 +37,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("research_policy", payload)
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
+        self.assertIn("execution_surface_policy", payload)
 
     def test_project_templates_include_minimal_core(self) -> None:
         for rel in (
@@ -86,13 +88,33 @@ class RepoKernelCanonTests(unittest.TestCase):
             "README.md",
             "SKILL.md",
             "references/BUG_INTAKE.md",
+            "references/EXECUTION_SURFACES.md",
             "templates/project/README.md",
             "templates/project/AGENTS.md",
             "templates/project/CONTRIBUTING.md",
         ):
             content = (ROOT / rel).read_text(encoding="utf-8")
+            if "EXECUTION_SURFACES" in rel:
+                self.assertIn("local", content.lower(), rel)
+                self.assertIn("GitHub Actions", content, rel)
+                continue
             self.assertIn("fingerprint", content, rel)
             self.assertIn("raw logs", content, rel)
+
+    def test_kernel_docs_and_templates_mention_local_first_execution(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/EXECUTION_SURFACES.md",
+            "references/BOOTSTRAP.md",
+            "references/GITHUB_DELIVERY.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("local", content.lower(), rel)
+            self.assertIn("GitHub Actions", content, rel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add explicit local-first execution surface policy to the kernel
- make local/self-hosted execution primary for ordinary work and keep GitHub Actions for repo-native automation
- materialize the policy into bootstrap templates and kernel references
- clarify that auto bug issues belong in the target project repo, not in the kernel repo

## Linked issue

- Closes #4
- Parent / context: #3

Rule:
- use closing keywords only for the leaf issue this PR actually completes
- link parent epic/incident without closing it

## Scope

- `ENGINEERING_KERNEL.yaml`
- `SKILL.md`
- `README.md`
- `references/BOOTSTRAP.md`
- `references/BUG_INTAKE.md`
- `references/GITHUB_DELIVERY.md`
- `references/EXECUTION_SURFACES.md`
- bootstrap templates
- kernel tests
- active PRD

## Verification

- [x] code-path tests
- [x] build/runtime checks
- [x] config or source-of-truth sync checks
- [x] live verifier or runtime checks when required
- [x] rollback path considered

## Evidence

- Commands run:
- `.venv/bin/python -m unittest discover -s tests`
- `python3 scripts/bootstrap_project_kernel.py --target /tmp/agent-kernel-local-first-bootstrap --apply`
- `rg -n "local operator machine|GitHub Actions|paid GitHub-hosted Actions|self-hosted runners" /tmp/agent-kernel-local-first-bootstrap/README.md /tmp/agent-kernel-local-first-bootstrap/AGENTS.md /tmp/agent-kernel-local-first-bootstrap/CONTRIBUTING.md`
- `git diff --check`
- Key outputs / run URLs:
- `Ran 12 tests ... OK`
- bootstrap output contains local-first execution language in generated `README.md`, `AGENTS.md`, and `CONTRIBUTING.md`
