### PR TITLE
Add kernel sync review canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -13,6 +13,7 @@ layers:
     - prd_first_execution
     - research_policy
     - execution_surface_policy
+    - kernel_sync_policy
     - github_issue_tree
     - automatic_bug_intake
     - github_delivery_flow
@@ -87,6 +88,22 @@ execution_surface_policy:
     - detect_local_prerequisites_before_work_starts
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
     - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
+
+kernel_sync_policy:
+  protocol_name: kernel_sync_review
+  decision_field: kernel_impact
+  allowed_kernel_impact_values:
+    - none
+    - project_local_only
+    - promote_to_kernel
+  rules:
+    - every_serious_slice_must_end_with_kernel_sync_review
+    - do_not_create_a_separate_skill_name_for_kernel_sync_when_engineering_kernel_already_applies
+    - promote_only_reusable_process_or_pattern_learnings_not_project_specific_operational_details
+    - kernel_impact_must_be_recorded_in_the_active_prd_or_closeout
+    - if_kernel_impact_is_promote_to_kernel_open_or_update_work_in_the_kernel_repo
+    - if_learning_is_project_specific_keep_it_in_project_local_canon_not_the_universal_kernel
+    - kernel_sync_review_happens_after_live_verification_not_before
 
 github_issue_tree:
   parent: Epic

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository is the standalone source-of-truth for:
 - project bootstrap templates
 - a reusable Codex skill
 - repo-managed GitHub metadata and community-health baseline
+- kernel sync review for promoting proven project learnings back into the universal kernel
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 
@@ -48,6 +49,14 @@ Research canon:
 - official docs for external contracts
 - known URLs fetched directly when already available
 
+Kernel sync canon:
+
+- every serious slice ends with `kernel_sync_review`
+- `kernel_impact` must be classified as `none`, `project_local_only`, or `promote_to_kernel`
+- active PRDs and serious closeouts carry an explicit `Kernel Impact` decision
+- only reusable process patterns belong in the universal kernel
+- project-specific ops details stay in the project-local canon
+
 Model-specific behavior is a thin adapter only:
 
 - tool selection
@@ -71,6 +80,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - model adapter policy
 - [references/EXECUTION_SURFACES.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/EXECUTION_SURFACES.md)
   - local-first versus GitHub Actions execution policy
+- [references/KERNEL_SYNC_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_SYNC_POLICY.md)
+  - how kernel learnings are promoted without polluting the universal core
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
   - how branch/PR/merge flow should work end-to-end
 - [references/BUG_INTAKE.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/BUG_INTAKE.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,6 +12,7 @@ Read [references/BOOTSTRAP.md](references/BOOTSTRAP.md) when you need to materia
 Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user asks how the kernel should map across GPT/Codex and Claude-style agents.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
+Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
 Read [references/GITHUB_DELIVERY.md](references/GITHUB_DELIVERY.md) when the user asks how branch/PR/merge flow should work end-to-end.
 Read [references/BUG_INTAKE.md](references/BUG_INTAKE.md) when the user asks how runtime failures should become GitHub `Bug` issues without noisy duplication.
 
@@ -30,6 +31,8 @@ The bug-intake rule is explicit:
 - establishing automatic deduplicated GitHub bug intake
 - establishing Tavily-first research behavior
 - establishing local-first execution and prerequisite bootstrap
+- establishing kernel sync review and kernel impact discipline
+- running the `kernel_sync_review` closure protocol
 - establishing branch / draft PR / merge discipline
 - creating project-local canon files and templates
 - creating repo-managed GitHub metadata and community-health files
@@ -55,6 +58,7 @@ The bug-intake rule is explicit:
 - PRD-first execution
 - issue tree
 - local-first execution surface
+- kernel sync review
 - PR verification contract
 - ownership and labels
 - research policy
@@ -85,5 +89,7 @@ Prefer a small durable set of outputs:
 - `CODEOWNERS`
 - active PRD / decision record
 - explicit bug-intake policy for verifier/watchdog/runtime incidents
+- explicit `kernel_impact` field in PRD/closeout flow
+- explicit `Kernel Impact` closeout decision after serious slices
 
 Use the templates in [templates/project](/Users/raketa23/Work/Vs/agent-engineering-kernel/templates/project) when bootstrapping a repo.

--- a/docs/kernel-sync-review-prd-2026-04-17.md
+++ b/docs/kernel-sync-review-prd-2026-04-17.md
@@ -1,0 +1,52 @@
+# PRD: Kernel Sync Review Canon
+
+Date: `2026-04-17`
+
+Status: `active`
+
+## Problem
+
+The kernel does not yet formalize how live project learnings should be reviewed and promoted back into the universal kernel. Without that rule, agents either forget reusable lessons or pollute the kernel with project-local specifics.
+
+## Current State
+
+The kernel already defines PRD-first execution, issue hierarchy, local-first execution, and automatic bug intake. It does not yet define a required closure step for deciding whether a finished slice has reusable kernel impact.
+
+## Target State
+
+The kernel defines one formal sub-protocol:
+
+- `kernel_sync_review`
+
+And one required decision field:
+
+- `kernel_impact = none | project_local_only | promote_to_kernel`
+
+Templates, docs, and machine-readable kernel state all carry this canon so new projects inherit it automatically.
+
+## Write Scope
+
+- `ENGINEERING_KERNEL.yaml`
+- `SKILL.md`
+- `README.md`
+- `references/BOOTSTRAP.md`
+- `references/KERNEL_SYNC_POLICY.md`
+- `templates/project/AGENTS.md`
+- `templates/project/CONTRIBUTING.md`
+- `templates/project/docs/PRD_TEMPLATE.md`
+- kernel tests
+
+## Rollout
+
+1. Add machine-readable kernel sync policy.
+2. Add reference documentation and skill wiring.
+3. Add template-level `Kernel Impact`.
+4. Update tests and bootstrap verification.
+
+## Verification Matrix
+
+- code-path tests: kernel unit tests
+- build/runtime checks: bootstrap apply into temp target
+- source-of-truth / sync checks: generated files contain new canon
+- live checks: GitHub issue/PR flow in kernel repo
+- rollback validation: revert kernel sync policy files and rerun tests

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -36,6 +36,8 @@ The bootstrapped canon should also make explicit:
 - whether the repo uses self-hosted runners
 - which workflows must stay in GitHub Actions
 - that routine development and verification should not default to paid GitHub-hosted Actions
+- that each serious slice ends with `kernel_sync_review`
+- that active PRDs and closeouts carry a `Kernel Impact` decision
 
 ## How to use the templates
 

--- a/references/KERNEL_SYNC_POLICY.md
+++ b/references/KERNEL_SYNC_POLICY.md
@@ -1,0 +1,53 @@
+# Kernel Sync Policy
+
+Use this reference when deciding whether a live project learning belongs in the universal kernel.
+
+## Canonical names
+
+- protocol: `kernel_sync_review`
+- decision field: `kernel_impact`
+
+Do not split this into a separate skill name when `engineering-kernel` already applies. The safe pattern is one kernel skill with a formal sub-protocol.
+
+## Allowed `kernel_impact` values
+
+- `none`
+  - the slice changed product/runtime behavior only
+  - no reusable engineering-process learning was added
+- `project_local_only`
+  - the slice produced a durable rule, but it is specific to this repository, runtime, vendor, or topology
+- `promote_to_kernel`
+  - the slice produced a reusable engineering rule, workflow, template, or verification pattern that future projects should inherit
+
+## Promotion test
+
+Promote only when all are true:
+
+- the learning was validated on a real project, not guessed in chat
+- the learning is process-level or pattern-level, not path/host/service specific
+- the learning reduces future agent dependence on chat memory
+- the learning is likely to recur in another serious repository
+
+## Required timing
+
+Run `kernel_sync_review` only after:
+
+- implementation is complete
+- verification is green
+- live/runtime acceptance is complete when relevant
+
+Do not promote half-proven ideas into the kernel.
+
+## Required output
+
+Every serious slice should end with:
+
+- `Kernel Impact: none | project_local_only | promote_to_kernel`
+- short justification
+- exact reusable artifact to update when promoting
+
+If `kernel_impact = promote_to_kernel`:
+
+- open or update the linked work in the kernel repository
+- update machine-readable kernel state, references, templates, and tests
+- keep project-specific residue in the project repo, not in the kernel

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -26,6 +26,16 @@ This repository follows the agent engineering kernel.
 - if the repo defines a local bootstrap path, use or repair it before escalating elsewhere
 - use GitHub Actions for repository-native automation, schedules, deploys, and hosted verification that genuinely belongs there
 
+## Kernel sync canon
+
+- every serious slice ends with `kernel_sync_review`
+- record `Kernel Impact` as one of:
+  - `none`
+  - `project_local_only`
+  - `promote_to_kernel`
+- only promote reusable process patterns into the universal kernel
+- keep project-specific operational rules in this repository, not in the universal kernel
+
 ## GitHub workflow canon
 
 - non-trivial work starts from a parent GitHub issue

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -34,6 +34,16 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 - reopen or update the existing bug issue when the fingerprint matches
 - create a new bug issue only when no open issue already tracks that fingerprint
 
+## Kernel sync review
+
+- every serious slice must end with `kernel_sync_review`
+- record `Kernel Impact` as:
+  - `none`
+  - `project_local_only`
+  - `promote_to_kernel`
+- use `promote_to_kernel` only for reusable engineering workflow or verification patterns
+- keep repository-specific ops canon in the project repo instead of polluting the universal kernel
+
 ## PR rule
 
 - one PR should normally close one leaf issue

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -31,3 +31,17 @@ Phased plan with validation and rollback.
 - source-of-truth / sync checks
 - live checks
 - rollback validation
+
+## Kernel Impact
+
+Record this during `kernel_sync_review`.
+
+Choose one:
+
+- `none`
+- `project_local_only`
+- `promote_to_kernel`
+
+Why:
+
+Explain whether this slice produced a reusable engineering rule or only a project-local decision.

--- a/tests/test_bootstrap_project_kernel.py
+++ b/tests/test_bootstrap_project_kernel.py
@@ -57,6 +57,8 @@ class BootstrapProjectKernelTests(unittest.TestCase):
             self.assertIn("raw logs", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("local operator machine", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("GitHub Actions", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("kernel_sync_review", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("Kernel Impact", (target / "docs" / "PRD_TEMPLATE.md").read_text(encoding="utf-8"))
             self.assertIn("paid GitHub-hosted Actions", (target / "CONTRIBUTING.md").read_text(encoding="utf-8"))
 
 

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -24,6 +24,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/BOOTSTRAP.md",
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
+            "references/KERNEL_SYNC_POLICY.md",
             "references/MODEL_ADAPTERS.md",
             "references/RESEARCH_POLICY.md",
             "references/GITHUB_DELIVERY.md",
@@ -38,6 +39,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
         self.assertIn("execution_surface_policy", payload)
+        self.assertIn("kernel_sync_policy", payload)
 
     def test_project_templates_include_minimal_core(self) -> None:
         for rel in (
@@ -115,6 +117,21 @@ class RepoKernelCanonTests(unittest.TestCase):
             content = (ROOT / rel).read_text(encoding="utf-8")
             self.assertIn("local", content.lower(), rel)
             self.assertIn("GitHub Actions", content, rel)
+
+    def test_kernel_docs_and_templates_mention_kernel_sync_review(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/KERNEL_SYNC_POLICY.md",
+            "references/BOOTSTRAP.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("kernel", content.lower(), rel)
+            self.assertIn("kernel_sync_review", content, rel)
+            self.assertIn("Kernel Impact", content, rel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add a formal kernel_sync_review closure protocol and Kernel Impact decision to the standalone engineering kernel so live project learnings can be promoted safely.

## Linked issue
Closes #7
Parent: #6

## Verification
- .venv/bin/python -m unittest discover -s tests
- python3 scripts/bootstrap_project_kernel.py --target /private/tmp/agent-kernel-sync-bootstrap-2 --apply
- rg -n "kernel_sync_review|Kernel Impact" /private/tmp/agent-kernel-sync-bootstrap-2/AGENTS.md /private/tmp/agent-kernel-sync-bootstrap-2/CONTRIBUTING.md /private/tmp/agent-kernel-sync-bootstrap-2/docs/PRD_TEMPLATE.md
