### PR TITLE
Clarify optional GitHub Project adoption

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -153,6 +153,9 @@ github_delivery_flow:
     - when_using_gh_issue_or_pr_commands_from_shell_prefer_body_file_over_inline_body
     - never_embed_markdown_with_backticks_in_inline_double_quoted_gh_body_arguments
     - single_quoted_heredoc_is_an_acceptable_fallback_only_when_it_writes_the_body_file_first
+    - github_projects_are_optional_not_bootstrap_default
+    - adopt_github_projects_only_when_issue_first_execution_needs_shared_custom_fields_iterations_roadmaps_or_cross_repo_planning
+    - do_not_require_github_projects_for_data_driven_non_engineering_lanes
 
 pr_verification_contract:
   required_fields:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository is the standalone source-of-truth for:
 - a reusable Codex skill
 - repo-managed GitHub metadata and community-health baseline
 - kernel sync review for promoting proven project learnings back into the universal kernel
+- optional GitHub Projects layer only when the repository actually needs shared planning views beyond issue-first execution
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -33,6 +33,9 @@ Execution-surface rule:
 - when using `gh issue create`, `gh issue edit`, or `gh pr create` from shell, prefer `--body-file` over inline `--body`
 - never embed markdown with backticks or fenced code blocks in inline double-quoted `gh --body` arguments
 - acceptable fallback is a single-quoted heredoc such as `<<'EOF'` that writes the body file first
+- GitHub Projects are an optional planning layer, not a bootstrap default
+- adopt a Project when multiple simultaneous engineering epics need shared custom fields, iteration views, roadmap views, or cross-repo planning
+- do not require Projects when issue-first execution already covers the repo and the non-engineering lanes are data-driven outside GitHub Issues
 
 ## Why this matters
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -47,6 +47,7 @@ This repository follows the agent engineering kernel.
 - PR closes the leaf issue only, not the parent epic
 - when invoking `gh issue create`, `gh issue edit`, or `gh pr create` from shell, use `--body-file` instead of inline double-quoted `--body`
 - if a file is inconvenient, write it first with a single-quoted heredoc such as `<<'EOF'`
+- GitHub Projects are optional and threshold-based, not bootstrap default; adopt them only when engineering planning needs shared custom fields/views or cross-repo coordination
 
 ## Automatic bug intake canon
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -57,6 +57,12 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 - use `--body-file` for issue and PR bodies
 - if needed, create the body file with a single-quoted heredoc such as `<<'EOF'`
 
+## GitHub Projects
+
+- GitHub Projects are optional, not a default requirement
+- add them only when issue-first execution no longer gives enough shared planning surface
+- typical thresholds are shared custom fields, iteration/roadmap views, or cross-repo engineering planning
+
 ## Minimum PR contents
 
 - linked leaf issue

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -16,6 +16,7 @@ This repository follows the agent engineering kernel.
 - GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
 - PR closes the leaf issue only
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
+- GitHub Projects are optional and should be adopted only when issue-first execution needs shared fields/views or cross-repo planning
 
 ## Canon files
 

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -130,6 +130,18 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("--body-file", content, rel)
             self.assertIn("heredoc", content, rel)
 
+    def test_kernel_docs_and_templates_mention_optional_github_projects(self) -> None:
+        for rel in (
+            "README.md",
+            "references/GITHUB_DELIVERY.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("GitHub Projects", content, rel)
+            self.assertIn("optional", content.lower(), rel)
+
     def test_kernel_docs_and_templates_mention_kernel_sync_review(self) -> None:
         for rel in (
             "README.md",


### PR DESCRIPTION
Closes #10

## Summary

- document that GitHub Projects are optional and threshold-based in the engineering kernel
- keep Projects out of bootstrap-default workflow when issue-first execution is already sufficient
- add regression coverage for the new Projects guidance

## Verification

- `.venv/bin/python -m unittest tests.test_repo_kernel_canon`
