### PR TITLE
Task #12: Add research boundary classification to universal kernel

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -65,10 +65,27 @@ research_policy:
       - Tavily research
     known_urls_or_known_docs:
       - fetch_or_index_the_known_url
+  slice_classification:
+    allowed_values:
+      - repo_local_slice
+      - external_contract_slice
+    repo_local_slice_means:
+      - repo_owned_ui_copy_layout_or_navigation_only
+      - local_state_or_deterministic_tests_only
+      - internal_docs_for_already_verified_repo_behavior_only
+    external_contract_slice_means:
+      - dependency_source_or_packaging_claims
+      - vendor_or_platform_behavior_claims
+      - external_auth_or_api_contract_claims
+      - interpreter_or_dependency_compatibility_claims
   rules:
     - research_is_tavily_first
+    - classify_each_non_trivial_slice_as_repo_local_or_external_contract_before_edits
+    - repo_local_slice_may_proceed_from_project_truth_deterministic_verification_and_local_runtime_checks
+    - external_contract_slice_requires_fresh_external_research_before_code_or_docs_land
     - use_official_vendor_docs_for_external_contracts
     - distinguish_verified_facts_from_assumptions
+    - external_contract_slice_evidence_must_be_recorded_in_the_active_prd_or_decision_note
     - if_known_url_exists_fetch_it_directly_instead_of_re-searching_blindly
     - if_primary_tool_is_unavailable_record_the_gap_and_use_the_best_documented_fallback
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Bug-intake canon:
 Research canon:
 
 - Tavily first
+- classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
+- `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
+- `external_contract_slice` requires fresh external research before code or docs land
 - official docs for external contracts
 - known URLs fetched directly when already available
 
@@ -84,6 +87,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - local-first versus GitHub Actions execution policy
 - [references/KERNEL_SYNC_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_SYNC_POLICY.md)
   - how kernel learnings are promoted without polluting the universal core
+- [references/RESEARCH_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/RESEARCH_POLICY.md)
+  - how research works, including the repo-local versus external-contract boundary
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
   - how branch/PR/merge flow should work end-to-end
 - [references/BUG_INTAKE.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/BUG_INTAKE.md)
@@ -96,6 +101,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - repo-managed label sync for the kernel repo itself
 - [docs/agent-engineering-kernel-prd-2026-04-17.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/agent-engineering-kernel-prd-2026-04-17.md)
   - decision record for this repository
+- [docs/research-boundary-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/research-boundary-prd-2026-04-18.md)
+  - decision record for the research-boundary classification rule
 
 ## Bootstrap a project
 

--- a/docs/research-boundary-prd-2026-04-18.md
+++ b/docs/research-boundary-prd-2026-04-18.md
@@ -1,0 +1,75 @@
+# PRD: Research Boundary Classification
+
+Date: `2026-04-18`
+
+Status: `active`
+
+Primary Task: `#12`
+
+## Problem
+
+The universal kernel already says research matters and official docs should verify external contracts.
+
+That is not yet specific enough.
+
+Without an explicit boundary, agents make two opposite mistakes:
+
+- they over-research repo-local UI or documentation slices that only need project truth and deterministic verification;
+- they under-research dependency, vendor-platform, auth-contract, or compatibility slices and ship them from stale memory.
+
+## Canonical distinction
+
+Every non-trivial slice must be classified before edits as exactly one of:
+
+- `repo_local_slice`
+- `external_contract_slice`
+
+### `repo_local_slice`
+
+Use this only when the work changes repository-owned behavior such as:
+
+- local UI copy, layout, navigation, or progressive disclosure
+- local state and deterministic tests
+- internal docs that describe already verified project behavior
+
+Execution rule:
+
+- project truth, deterministic verification, and local runtime checks are sufficient;
+- fresh external research is optional.
+
+### `external_contract_slice`
+
+Use this whenever the work changes or claims current behavior for any changing outside system such as:
+
+- dependency source, version, install flow, or packaging
+- vendor/platform/API behavior
+- external authentication/runtime assumptions
+- interpreter or dependency compatibility
+
+Execution rule:
+
+- fresh external research is mandatory before code or docs land;
+- prefer official docs and primary upstream/vendor sources;
+- record evidence in the active PRD or decision note instead of leaving it only in chat.
+
+## Files To Change
+
+- `ENGINEERING_KERNEL.yaml`
+- `references/RESEARCH_POLICY.md`
+- `README.md`
+- `templates/project/README.md`
+- `templates/project/AGENTS.md`
+- `templates/project/CONTRIBUTING.md`
+- `tests/test_repo_kernel_canon.py`
+
+## Verification
+
+- `.venv/bin/python -m unittest discover -s tests`
+- `git diff --check`
+
+## Success Condition
+
+The kernel is complete for this slice when future projects bootstrap a non-ambiguous research rule:
+
+- repo-local slices can move from local truth without fake upstream discovery;
+- external-contract slices cannot land without fresh external research and recorded evidence.

--- a/references/RESEARCH_POLICY.md
+++ b/references/RESEARCH_POLICY.md
@@ -11,10 +11,34 @@ The kernel is research-first, not guess-first.
 ## Rules
 
 - research is Tavily-first
+- classify each non-trivial slice before edits as either `repo_local_slice` or `external_contract_slice`
+- `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
+- `external_contract_slice` requires fresh external research before code or docs land
 - for vendor/platform/API behavior, verify the external contract from official docs
 - separate verified facts from assumptions
+- record external-contract evidence in the active PRD or decision note instead of leaving it only in chat
 - if a known URL already exists, fetch or index it directly instead of re-running broad search
 - if Tavily or the preferred stack is unavailable, record the capability gap and use the best documented fallback
+
+## Research boundary
+
+Use `repo_local_slice` only when the work is limited to repository-owned behavior such as:
+
+- local UI copy, layout, navigation, or progressive disclosure
+- local component state or deterministic tests
+- internal docs that describe already verified project behavior
+
+Use `external_contract_slice` whenever the work changes or asserts current behavior for any changing outside system such as:
+
+- dependency source, version, install flow, or packaging claims
+- vendor/platform/API behavior
+- external authentication/runtime assumptions
+- interpreter or dependency compatibility claims
+
+The boundary exists to prevent two opposite mistakes:
+
+- over-researching a pure repo-local slice as if it were an upstream-contract change
+- shipping an external-contract slice from stale memory or old assumptions
 
 ## What research should produce
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -14,6 +14,9 @@ This repository follows the agent engineering kernel.
 ## Research canon
 
 - use Tavily first for research
+- classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
+- `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
+- `external_contract_slice` requires fresh external research before code or docs land
 - use official vendor docs to verify external contracts
 - if a known URL already exists, fetch/index it directly instead of re-running broad search
 - distinguish verified facts from assumptions

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -5,6 +5,9 @@ This repository uses a PRD-first and issue-first engineering workflow.
 ## Research policy
 
 - Tavily first
+- classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
+- `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
+- `external_contract_slice` requires fresh external research before code or docs land
 - official docs for external contracts
 - known URLs should be fetched/indexed directly when available
 - verified facts must be separated from assumptions

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -6,6 +6,9 @@ This repository follows the agent engineering kernel.
 
 - non-trivial work is PRD-first
 - non-trivial work starts from a parent GitHub issue
+- each non-trivial slice is classified before edits as `repo_local_slice` or `external_contract_slice`
+- repo-owned slices may proceed from project truth, deterministic verification, and local runtime checks
+- slices that change or claim current external-system behavior require fresh external research before code or docs land
 - GitHub hierarchy:
   - `Epic`
   - `Task`

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -40,6 +40,16 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("automatic_bug_intake", payload)
         self.assertIn("execution_surface_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
+        research_policy = payload["research_policy"]
+        self.assertIn("slice_classification", research_policy)
+        self.assertEqual(
+            research_policy["slice_classification"]["allowed_values"],
+            ["repo_local_slice", "external_contract_slice"],
+        )
+        self.assertIn(
+            "external_contract_slice_requires_fresh_external_research_before_code_or_docs_land",
+            research_policy["rules"],
+        )
 
     def test_project_templates_include_minimal_core(self) -> None:
         for rel in (
@@ -117,6 +127,19 @@ class RepoKernelCanonTests(unittest.TestCase):
             content = (ROOT / rel).read_text(encoding="utf-8")
             self.assertIn("local", content.lower(), rel)
             self.assertIn("GitHub Actions", content, rel)
+
+    def test_kernel_docs_and_templates_mention_research_boundary(self) -> None:
+        for rel in (
+            "README.md",
+            "references/RESEARCH_POLICY.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("repo_local_slice", content, rel)
+            self.assertIn("external_contract_slice", content, rel)
+            self.assertIn("fresh external research", content, rel)
 
     def test_kernel_docs_and_templates_mention_shell_safe_gh_delivery(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary
Promotes the verified research-boundary rule from `telethone` into the universal kernel.

## Scope
- add machine-readable `repo_local_slice` vs `external_contract_slice` classification to `ENGINEERING_KERNEL.yaml`
- expand `references/RESEARCH_POLICY.md`
- update project templates so future repos inherit the rule
- add regression coverage

Closes #12
