### PR TITLE
Add kernel upstream awareness canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -13,6 +13,7 @@ layers:
     - prd_first_execution
     - research_policy
     - execution_surface_policy
+    - kernel_upstream_awareness_policy
     - kernel_sync_policy
     - github_issue_tree
     - automatic_bug_intake
@@ -106,6 +107,28 @@ execution_surface_policy:
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
     - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
 
+kernel_upstream_awareness_policy:
+  protocol_name: kernel_upstream_check
+  consumer_metadata_file: .kernel/upstream.json
+  canonical_statuses:
+    - current
+    - update_available
+    - not_configured
+    - unknown
+  required_metadata_fields:
+    - kernel_repo
+    - kernel_default_branch
+    - pinned_commit
+  rules:
+    - every_serious_consumer_project_slice_should_begin_with_kernel_upstream_check
+    - downstream_projects_must_record_an_exact_pinned_kernel_commit
+    - kernel_upstream_check_compares_the_pinned_commit_against_upstream_default_branch_head
+    - if_update_is_available_record_it_in_the_active_slice_or_open_or_update_a_project_local_task
+    - kernel_updates_must_not_auto_apply_blindly_to_downstream_projects
+    - kernel_adoption_remains_a_normal_project_local_slice_with_prd_issue_verification_and_merge
+    - urgent_incident_work_may_defer_kernel_adoption_but_must_not_hide_the_drift
+    - optional_operator_fleet_checks_may_call_the_same_protocol_across_multiple_repositories_but_are_not_bootstrap_default
+
 kernel_sync_policy:
   protocol_name: kernel_sync_review
   decision_field: kernel_impact
@@ -121,6 +144,7 @@ kernel_sync_policy:
     - if_kernel_impact_is_promote_to_kernel_open_or_update_work_in_the_kernel_repo
     - if_learning_is_project_specific_keep_it_in_project_local_canon_not_the_universal_kernel
     - kernel_sync_review_happens_after_live_verification_not_before
+    - do_not_use_kernel_sync_review_as_a_substitute_for_kernel_upstream_check
 
 github_issue_tree:
   parent: Epic

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository is the standalone source-of-truth for:
 - repo-managed GitHub metadata and community-health baseline
 - kernel sync review for promoting proven project learnings back into the universal kernel
 - optional GitHub Projects layer only when the repository actually needs shared planning views beyond issue-first execution
+- kernel upstream awareness so consumer repositories can detect kernel drift explicitly
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 
@@ -56,6 +57,10 @@ Research canon:
 
 Kernel sync canon:
 
+- every serious consumer-project slice begins with `kernel_upstream_check`
+- consumer repositories carry `.kernel/upstream.json` with an exact pinned kernel commit
+- if upstream differs from the pinned commit, the project records `update_available` and either opens/updates a project-local task or explicitly defers adoption
+- downstream repositories never auto-apply kernel changes blindly
 - every serious slice ends with `kernel_sync_review`
 - `kernel_impact` must be classified as `none`, `project_local_only`, or `promote_to_kernel`
 - active PRDs and serious closeouts carry an explicit `Kernel Impact` decision
@@ -87,6 +92,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - local-first versus GitHub Actions execution policy
 - [references/KERNEL_SYNC_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_SYNC_POLICY.md)
   - how kernel learnings are promoted without polluting the universal core
+- [references/KERNEL_UPSTREAM_AWARENESS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_UPSTREAM_AWARENESS.md)
+  - how consumer repositories notice upstream kernel changes and decide whether to adopt them
 - [references/RESEARCH_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/RESEARCH_POLICY.md)
   - how research works, including the repo-local versus external-contract boundary
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
@@ -99,6 +106,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - deterministic template copier
 - [scripts/sync_github_labels.py](/Users/raketa23/Work/Vs/agent-engineering-kernel/scripts/sync_github_labels.py)
   - repo-managed label sync for the kernel repo itself
+- [scripts/check_kernel_upstream.py](/Users/raketa23/Work/Vs/agent-engineering-kernel/scripts/check_kernel_upstream.py)
+  - local-first kernel drift check for consumer repositories
 - [docs/agent-engineering-kernel-prd-2026-04-17.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/agent-engineering-kernel-prd-2026-04-17.md)
   - decision record for this repository
 - [docs/research-boundary-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/research-boundary-prd-2026-04-18.md)
@@ -129,6 +138,12 @@ Sync the kernel repo labels from file to GitHub:
 ```bash
 python3 scripts/sync_github_labels.py --dry-run
 python3 scripts/sync_github_labels.py --apply
+```
+
+Check whether a consumer project is behind the current kernel:
+
+```bash
+python3 scripts/check_kernel_upstream.py --json
 ```
 
 ## Validate this repository

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user 
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
+Read [references/KERNEL_UPSTREAM_AWARENESS.md](references/KERNEL_UPSTREAM_AWARENESS.md) when the user asks how consumer projects should notice upstream kernel changes and decide whether to adopt them.
 Read [references/GITHUB_DELIVERY.md](references/GITHUB_DELIVERY.md) when the user asks how branch/PR/merge flow should work end-to-end.
 Read [references/BUG_INTAKE.md](references/BUG_INTAKE.md) when the user asks how runtime failures should become GitHub `Bug` issues without noisy duplication.
 
@@ -32,6 +33,8 @@ The bug-intake rule is explicit:
 - establishing Tavily-first research behavior
 - establishing local-first execution and prerequisite bootstrap
 - establishing kernel sync review and kernel impact discipline
+- establishing kernel upstream awareness and downstream adoption checks
+- running the `kernel_upstream_check` protocol in consumer repositories
 - running the `kernel_sync_review` closure protocol
 - establishing branch / draft PR / merge discipline
 - creating project-local canon files and templates
@@ -58,6 +61,7 @@ The bug-intake rule is explicit:
 - PRD-first execution
 - issue tree
 - local-first execution surface
+- kernel upstream awareness
 - kernel sync review
 - PR verification contract
 - ownership and labels

--- a/docs/kernel-upstream-awareness-prd-2026-04-18.md
+++ b/docs/kernel-upstream-awareness-prd-2026-04-18.md
@@ -1,0 +1,110 @@
+# PRD: Kernel upstream awareness for multi-project consumers
+
+Date: `2026-04-18`
+
+Status: `completed`
+
+## Problem
+
+`agent-engineering-kernel` is now shared by multiple repositories. One project can promote a learning into the kernel, while another consumer project remains pinned to an older kernel state without any explicit awareness check. Template/bootstrap repos do not auto-sync after generation, so downstream drift is currently silent unless an operator notices it manually.
+
+## Research Basis
+
+- Slice classification: `external_contract_slice`
+- Tavily-first research used: `yes`
+- Official docs used: `yes`
+
+Confirmed external facts:
+
+- GitHub template repositories are one-time generation, not built-in sync channels.
+- GitHub documents releases/tags as the canonical way to view version history.
+- Community tooling such as `cruft` uses explicit pinned upstream commit metadata plus `check/update` commands instead of silent propagation.
+
+## Current State
+
+Verified facts only.
+
+- Kernel already has `kernel_sync_review` / `Kernel Impact` for promoting learnings back into the upstream kernel.
+- Kernel does not yet define the inverse check for consumer repos.
+- Bootstrapped projects do not yet record which exact kernel commit they came from.
+- Bootstrapped projects do not yet ship a canonical upstream-check script.
+
+## Target State
+
+- Kernel defines a formal `kernel_upstream_check` protocol for consumer projects.
+- Every bootstrapped consumer repo carries `.kernel/upstream.json` with:
+  - upstream repo URL
+  - upstream default branch
+  - exact pinned kernel commit
+- Every bootstrapped consumer repo ships `scripts/check_kernel_upstream.py`.
+- Consumer repos can detect `current | update_available | not_configured | unknown`.
+- If drift exists, the project opens/updates a local `Task` or explicitly documents deferral.
+- Kernel changes are never auto-applied blindly.
+
+## Write Scope
+
+- `SKILL.md`
+- `ENGINEERING_KERNEL.yaml`
+- `README.md`
+- `references/BOOTSTRAP.md`
+- `references/GITHUB_DELIVERY.md`
+- `references/KERNEL_SYNC_POLICY.md`
+- new `references/KERNEL_UPSTREAM_AWARENESS.md`
+- `scripts/bootstrap_project_kernel.py`
+- new `scripts/check_kernel_upstream.py`
+- `templates/project/AGENTS.md`
+- `templates/project/README.md`
+- `templates/project/CONTRIBUTING.md`
+- `templates/project/docs/PRD_TEMPLATE.md`
+- new `templates/project/.kernel/upstream.json`
+- new `templates/project/scripts/check_kernel_upstream.py`
+- tests
+
+## Rollout
+
+### Phase 1
+- Add the new upstream-awareness canon and reference docs.
+- Validation:
+  - machine-readable kernel parses
+  - docs mention `kernel_upstream_check`
+
+### Phase 2
+- Materialize consumer metadata and check script in templates/bootstrap.
+- Validation:
+  - bootstrap dry-run/apply includes the new files
+  - `.kernel/upstream.json` is pinned to the current kernel commit, not placeholder junk
+
+### Phase 3
+- Add regression tests for current/update/not-configured states.
+- Validation:
+  - targeted tests pass
+  - end-to-end bootstrap + local checker output is stable
+
+## Verification Matrix
+
+- code-path tests
+  - parser/checker tests for `current`, `update_available`, `not_configured`
+- build/runtime checks
+  - `py_compile` for added scripts
+- source-of-truth / sync checks
+  - bootstrapped `.kernel/upstream.json` contains current kernel commit
+- live checks
+  - run the checker against the local kernel repo and a bootstrapped temp consumer repo
+- rollback validation
+  - reverting the new canon removes the metadata/check protocol cleanly
+
+## Kernel Impact
+
+- `promote_to_kernel`
+
+Why:
+
+This is universal process canon for any project consuming a shared upstream engineering kernel.
+
+## Final State
+
+- `kernel_upstream_check` is now a formal kernel protocol.
+- consumer bootstrap now materializes `.kernel/upstream.json` with the exact pinned kernel commit
+- consumer bootstrap now materializes `scripts/check_kernel_upstream.py`
+- downstream status values are canonicalized as `current | update_available | not_configured | unknown`
+- local-first verification proved that a freshly bootstrapped consumer project reports `current` against the live kernel repo

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -27,6 +27,8 @@ Write or update:
 - `.github/CODEOWNERS`
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
+- `scripts/check_kernel_upstream.py`
+- `.kernel/upstream.json`
 - one active PRD / decision doc
 
 The bootstrapped canon should also make explicit:
@@ -36,8 +38,10 @@ The bootstrapped canon should also make explicit:
 - whether the repo uses self-hosted runners
 - which workflows must stay in GitHub Actions
 - that routine development and verification should not default to paid GitHub-hosted Actions
+- that each serious slice begins with `kernel_upstream_check`
 - that each serious slice ends with `kernel_sync_review`
 - that active PRDs and closeouts carry a `Kernel Impact` decision
+- that the consumer project pins the exact kernel commit it bootstrapped from
 
 ## How to use the templates
 
@@ -55,6 +59,8 @@ python3 scripts/sync_github_labels.py --apply
 ```
 
 Do not blindly overwrite stronger project-local canon unless the task is an intentional migration.
+
+Bootstrap should pin the current kernel commit into `.kernel/upstream.json` instead of leaving placeholder or branch-only metadata.
 
 If the target repository needs a license, choose it intentionally for that project instead of copying a random default.
 

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -30,6 +30,7 @@ Execution-surface rule:
 - prefer squash merge unless the project canon explicitly chooses another method
 - automatic bug intake opens or updates the `Bug` issue before the fix slice starts
 - repeated incidents should update the existing bug issue for the same fingerprint instead of spawning duplicates
+- if `kernel_upstream_check` reports `update_available`, open or update a project-local `Task` unless the active slice explicitly documents a deferral
 - when using `gh issue create`, `gh issue edit`, or `gh pr create` from shell, prefer `--body-file` over inline `--body`
 - never embed markdown with backticks or fenced code blocks in inline double-quoted `gh --body` arguments
 - acceptable fallback is a single-quoted heredoc such as `<<'EOF'` that writes the body file first

--- a/references/KERNEL_SYNC_POLICY.md
+++ b/references/KERNEL_SYNC_POLICY.md
@@ -9,6 +9,11 @@ Use this reference when deciding whether a live project learning belongs in the 
 
 Do not split this into a separate skill name when `engineering-kernel` already applies. The safe pattern is one kernel skill with a formal sub-protocol.
 
+This protocol does not replace `kernel_upstream_check`.
+
+- `kernel_upstream_check` asks whether the consumer repository is behind the kernel
+- `kernel_sync_review` asks whether the just-finished slice should update the kernel
+
 ## Allowed `kernel_impact` values
 
 - `none`

--- a/references/KERNEL_UPSTREAM_AWARENESS.md
+++ b/references/KERNEL_UPSTREAM_AWARENESS.md
@@ -1,0 +1,62 @@
+# Kernel Upstream Awareness
+
+Use this reference when a shared `agent-engineering-kernel` is consumed by multiple downstream repositories.
+
+## Problem
+
+Template/bootstrap repos do not self-sync after generation. If one project promotes a learning into the kernel, other consumer repos need a deterministic way to notice that upstream changed and decide whether to adopt it.
+
+## Canonical names
+
+- protocol: `kernel_upstream_check`
+- consumer metadata file: `.kernel/upstream.json`
+
+Do not confuse this with `kernel_sync_review`.
+
+- `kernel_upstream_check` happens near slice start in the consumer project
+- `kernel_sync_review` happens near slice end after verification
+
+## Required consumer metadata
+
+Every bootstrapped consumer repository should carry:
+
+- upstream kernel repository URL
+- upstream default branch
+- exact pinned kernel commit used by the consumer project
+
+The pin must be explicit and immutable.
+
+Do not treat template generation time as implicit truth.
+
+## Required rules
+
+- every serious consumer-project slice should begin with `kernel_upstream_check`
+- `kernel_upstream_check` compares the project's pinned kernel commit with the upstream kernel default-branch head
+- if upstream differs, record `update_available`
+- downstream projects must not auto-apply kernel changes blindly
+- kernel adoption remains an explicit project-local slice with PRD, issue tree, verification, and merge
+- urgent incident work is not blocked by an available kernel update, but the drift must be recorded or turned into a project-local task
+
+## Canonical statuses
+
+- `current`
+- `update_available`
+- `not_configured`
+- `unknown`
+
+## When update is available
+
+If `kernel_upstream_check` reports `update_available`:
+
+- open or update a project-local `Task` issue to review/adopt the kernel update
+- or explicitly defer the adoption in the active PRD/closeout
+
+Do not silently ignore the drift.
+
+## Optional operator layer
+
+An operator machine may run a local scheduled sweep across many repositories and call the same checker in each consumer repo.
+
+That fleet sweep is optional.
+
+It is not part of the bootstrap minimum because it depends on the operator's local topology.

--- a/scripts/bootstrap_project_kernel.py
+++ b/scripts/bootstrap_project_kernel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+import subprocess
 from pathlib import Path
 
 
@@ -11,12 +12,40 @@ TEMPLATES_ROOT = ROOT / "templates" / "project"
 
 
 def iter_template_files(root: Path = TEMPLATES_ROOT) -> list[Path]:
-    return sorted(path for path in root.rglob("*") if path.is_file())
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def build_replacements() -> dict[str, str]:
+    completed = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "__KERNEL_REPO_URL__": "https://github.com/alexxety/agent-engineering-kernel.git",
+        "__KERNEL_PINNED_COMMIT__": completed.stdout.strip(),
+    }
+
+
+def render_content(source: Path, replacements: dict[str, str]) -> str:
+    content = source.read_text(encoding="utf-8")
+    for needle, value in replacements.items():
+        content = content.replace(needle, value)
+    return content
 
 
 def copy_templates(target: Path, *, apply: bool, force: bool) -> tuple[list[str], list[str]]:
     created: list[str] = []
     skipped: list[str] = []
+    replacements = build_replacements()
     for source in iter_template_files():
         rel = source.relative_to(TEMPLATES_ROOT)
         destination = target / rel
@@ -26,7 +55,10 @@ def copy_templates(target: Path, *, apply: bool, force: bool) -> tuple[list[str]
         created.append(str(rel))
         if apply:
             destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, destination)
+            if source.suffix in {".json", ".md", ".yml", ".yaml", ".py"}:
+                destination.write_text(render_content(source, replacements), encoding="utf-8")
+            else:
+                shutil.copy2(source, destination)
     return created, skipped
 
 

--- a/scripts/check_kernel_upstream.py
+++ b/scripts/check_kernel_upstream.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_METADATA = ROOT / ".kernel" / "upstream.json"
+
+
+def load_metadata(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return payload
+
+
+def resolve_remote_head(repo_url: str, branch: str) -> str:
+    completed = subprocess.run(
+        ["git", "ls-remote", repo_url, f"refs/heads/{branch}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip() or "git ls-remote failed")
+    line = completed.stdout.strip()
+    if not line:
+        raise RuntimeError("remote branch not found")
+    return line.split()[0]
+
+
+def build_result(metadata_path: Path) -> dict:
+    payload = load_metadata(metadata_path)
+    if not payload:
+        return {
+            "status": "not_configured",
+            "metadata_path": str(metadata_path),
+        }
+
+    repo = str(payload.get("kernel_repo") or "").strip()
+    branch = str(payload.get("kernel_default_branch") or "").strip()
+    pinned_commit = str(payload.get("pinned_commit") or "").strip()
+    if not repo or not branch or not pinned_commit:
+        return {
+            "status": "unknown",
+            "metadata_path": str(metadata_path),
+            "error": "missing required metadata fields",
+            "kernel_repo": repo,
+            "kernel_default_branch": branch,
+            "pinned_commit": pinned_commit,
+        }
+
+    try:
+        remote_commit = resolve_remote_head(repo, branch)
+    except Exception as exc:  # pragma: no cover - exercised in tests with patching
+        return {
+            "status": "unknown",
+            "metadata_path": str(metadata_path),
+            "kernel_repo": repo,
+            "kernel_default_branch": branch,
+            "pinned_commit": pinned_commit,
+            "error": str(exc),
+        }
+
+    status = "current" if remote_commit == pinned_commit else "update_available"
+    return {
+        "status": status,
+        "metadata_path": str(metadata_path),
+        "kernel_repo": repo,
+        "kernel_default_branch": branch,
+        "pinned_commit": pinned_commit,
+        "remote_commit": remote_commit,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check whether a consumer repository is behind the upstream engineering kernel.")
+    parser.add_argument("--metadata", default=str(DEFAULT_METADATA), help="Path to .kernel/upstream.json")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--fail-if-update-available",
+        action="store_true",
+        help="Exit non-zero when upstream differs from the pinned kernel commit.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = build_result(Path(args.metadata).expanduser().resolve())
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for key in (
+            "status",
+            "metadata_path",
+            "kernel_repo",
+            "kernel_default_branch",
+            "pinned_commit",
+            "remote_commit",
+            "error",
+        ):
+            if key in result:
+                print(f"{key}: {result[key]}")
+    if args.fail_if_update_available and result.get("status") == "update_available":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/project/.kernel/upstream.json
+++ b/templates/project/.kernel/upstream.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "protocol": "kernel_upstream_check",
+  "kernel_repo": "__KERNEL_REPO_URL__",
+  "kernel_default_branch": "main",
+  "pinned_commit": "__KERNEL_PINNED_COMMIT__",
+  "update_policy": {
+    "auto_apply": false,
+    "open_or_update_project_task_when_drift_detected": true
+  }
+}

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -31,6 +31,10 @@ This repository follows the agent engineering kernel.
 
 ## Kernel sync canon
 
+- every serious slice begins with `kernel_upstream_check`
+- consumer metadata lives in `.kernel/upstream.json`
+- if `kernel_upstream_check` reports `update_available`, open or update a project-local `Task` or explicitly defer adoption in the active PRD/closeout
+- downstream repos do not auto-apply kernel changes blindly
 - every serious slice ends with `kernel_sync_review`
 - record `Kernel Impact` as one of:
   - `none`
@@ -88,9 +92,11 @@ This repository follows the agent engineering kernel.
 - `CONTRIBUTING.md`
 - `CODE_OF_CONDUCT.md`
 - `SECURITY.md`
+- `.kernel/upstream.json`
 - `.github/ISSUE_TEMPLATE/*`
 - `.github/pull_request_template.md`
 - `.github/CODEOWNERS`
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
+- `scripts/check_kernel_upstream.py`
 - active PRD / decision doc in `docs/`

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -39,6 +39,10 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 
 ## Kernel sync review
 
+- every serious slice should begin with `kernel_upstream_check`
+- consumer kernel metadata lives in `.kernel/upstream.json`
+- if upstream kernel drift exists, open or update a project-local `Task` or explicitly defer it in the active PRD/closeout
+- do not auto-apply kernel changes blindly into the project
 - every serious slice must end with `kernel_sync_review`
 - record `Kernel Impact` as:
   - `none`

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -17,6 +17,11 @@ This repository follows the agent engineering kernel.
 - ordinary development, debugging, and verification should run locally first
 - if the project has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
 - GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
+- serious slices begin with `kernel_upstream_check`
+- the project pins its upstream kernel commit in `.kernel/upstream.json`
+- kernel updates are adopted explicitly through normal project issues/PRDs, not auto-applied blindly
+- every serious slice ends with `kernel_sync_review`
+- serious closeouts record `Kernel Impact`
 - PR closes the leaf issue only
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
 - GitHub Projects are optional and should be adopted only when issue-first execution needs shared fields/views or cross-repo planning
@@ -28,9 +33,11 @@ This repository follows the agent engineering kernel.
 - `SECURITY.md`
 - `AGENTS.md`
 - `CONTRIBUTING.md`
+- `.kernel/upstream.json`
 - `.github/ISSUE_TEMPLATE/*`
 - `.github/pull_request_template.md`
 - `.github/CODEOWNERS`
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
+- `scripts/check_kernel_upstream.py`
 - active PRD in `docs/`

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -20,6 +20,14 @@ What should be true after the change.
 
 Files, workflows, services, or systems expected to change.
 
+## Kernel Upstream Check
+
+Record near slice start.
+
+- protocol: `kernel_upstream_check`
+- status: `current | update_available | not_configured | unknown`
+- action: `none | task_opened_or_updated | explicitly_deferred`
+
 ## Rollout
 
 Phased plan with validation and rollback.

--- a/templates/project/scripts/check_kernel_upstream.py
+++ b/templates/project/scripts/check_kernel_upstream.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_METADATA = ROOT / ".kernel" / "upstream.json"
+
+
+def load_metadata(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return payload
+
+
+def resolve_remote_head(repo_url: str, branch: str) -> str:
+    completed = subprocess.run(
+        ["git", "ls-remote", repo_url, f"refs/heads/{branch}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip() or "git ls-remote failed")
+    line = completed.stdout.strip()
+    if not line:
+        raise RuntimeError("remote branch not found")
+    return line.split()[0]
+
+
+def build_result(metadata_path: Path) -> dict:
+    payload = load_metadata(metadata_path)
+    if not payload:
+        return {
+            "status": "not_configured",
+            "metadata_path": str(metadata_path),
+        }
+
+    repo = str(payload.get("kernel_repo") or "").strip()
+    branch = str(payload.get("kernel_default_branch") or "").strip()
+    pinned_commit = str(payload.get("pinned_commit") or "").strip()
+    if not repo or not branch or not pinned_commit:
+        return {
+            "status": "unknown",
+            "metadata_path": str(metadata_path),
+            "error": "missing required metadata fields",
+            "kernel_repo": repo,
+            "kernel_default_branch": branch,
+            "pinned_commit": pinned_commit,
+        }
+
+    try:
+        remote_commit = resolve_remote_head(repo, branch)
+    except Exception as exc:  # pragma: no cover - exercised in root-kernel tests
+        return {
+            "status": "unknown",
+            "metadata_path": str(metadata_path),
+            "kernel_repo": repo,
+            "kernel_default_branch": branch,
+            "pinned_commit": pinned_commit,
+            "error": str(exc),
+        }
+
+    status = "current" if remote_commit == pinned_commit else "update_available"
+    return {
+        "status": status,
+        "metadata_path": str(metadata_path),
+        "kernel_repo": repo,
+        "kernel_default_branch": branch,
+        "pinned_commit": pinned_commit,
+        "remote_commit": remote_commit,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check whether this repository is behind the upstream engineering kernel.")
+    parser.add_argument("--metadata", default=str(DEFAULT_METADATA), help="Path to .kernel/upstream.json")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    parser.add_argument(
+        "--fail-if-update-available",
+        action="store_true",
+        help="Exit non-zero when upstream differs from the pinned kernel commit.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    result = build_result(Path(args.metadata).expanduser().resolve())
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for key in (
+            "status",
+            "metadata_path",
+            "kernel_repo",
+            "kernel_default_branch",
+            "pinned_commit",
+            "remote_commit",
+            "error",
+        ):
+            if key in result:
+                print(f"{key}: {result[key]}")
+    if args.fail_if_update_available and result.get("status") == "update_available":
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bootstrap_project_kernel.py
+++ b/tests/test_bootstrap_project_kernel.py
@@ -28,6 +28,8 @@ class BootstrapProjectKernelTests(unittest.TestCase):
         self.assertIn(".github/ISSUE_TEMPLATE/epic.yml", files)
         self.assertIn(".github/pull_request_template.md", files)
         self.assertIn("scripts/sync_github_labels.py", files)
+        self.assertIn("scripts/check_kernel_upstream.py", files)
+        self.assertIn(".kernel/upstream.json", files)
         self.assertIn("docs/PRD_TEMPLATE.md", files)
 
     def test_copy_templates_dry_run_skips_existing_without_force(self) -> None:
@@ -53,13 +55,19 @@ class BootstrapProjectKernelTests(unittest.TestCase):
             self.assertTrue((target / "SECURITY.md").exists())
             self.assertTrue((target / ".github" / "labels.yml").exists())
             self.assertTrue((target / "scripts" / "sync_github_labels.py").exists())
+            self.assertTrue((target / "scripts" / "check_kernel_upstream.py").exists())
+            self.assertTrue((target / ".kernel" / "upstream.json").exists())
             self.assertIn("fingerprint", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("raw logs", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("local operator machine", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("GitHub Actions", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("kernel_sync_review", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("kernel_upstream_check", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("Kernel Impact", (target / "docs" / "PRD_TEMPLATE.md").read_text(encoding="utf-8"))
             self.assertIn("paid GitHub-hosted Actions", (target / "CONTRIBUTING.md").read_text(encoding="utf-8"))
+            metadata = (target / ".kernel" / "upstream.json").read_text(encoding="utf-8")
+            self.assertIn("kernel_upstream_check", metadata)
+            self.assertNotIn("__KERNEL_PINNED_COMMIT__", metadata)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_kernel_upstream.py
+++ b/tests/test_check_kernel_upstream.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "check_kernel_upstream.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_kernel_upstream_module", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class KernelUpstreamCheckTests(unittest.TestCase):
+    def test_build_result_reports_not_configured_without_metadata(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            result = module.build_result(Path(tmp) / ".kernel" / "upstream.json")
+        self.assertEqual(result["status"], "not_configured")
+
+    def test_build_result_reports_current_when_commits_match(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata = Path(tmp) / "upstream.json"
+            metadata.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "protocol": "kernel_upstream_check",
+                        "kernel_repo": "https://github.com/alexxety/agent-engineering-kernel.git",
+                        "kernel_default_branch": "main",
+                        "pinned_commit": "abc123",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(module, "resolve_remote_head", return_value="abc123"):
+                result = module.build_result(metadata)
+        self.assertEqual(result["status"], "current")
+        self.assertEqual(result["remote_commit"], "abc123")
+
+    def test_build_result_reports_update_available_when_commits_differ(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata = Path(tmp) / "upstream.json"
+            metadata.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "protocol": "kernel_upstream_check",
+                        "kernel_repo": "https://github.com/alexxety/agent-engineering-kernel.git",
+                        "kernel_default_branch": "main",
+                        "pinned_commit": "abc123",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(module, "resolve_remote_head", return_value="def456"):
+                result = module.build_result(metadata)
+        self.assertEqual(result["status"], "update_available")
+        self.assertEqual(result["remote_commit"], "def456")
+
+    def test_main_emits_json(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata = Path(tmp) / "upstream.json"
+            metadata.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "protocol": "kernel_upstream_check",
+                        "kernel_repo": "https://github.com/alexxety/agent-engineering-kernel.git",
+                        "kernel_default_branch": "main",
+                        "pinned_commit": "abc123",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(module, "resolve_remote_head", return_value="abc123"):
+                with mock.patch("sys.argv", ["check_kernel_upstream.py", "--metadata", str(metadata), "--json"]):
+                    with mock.patch("builtins.print") as print_mock:
+                        exit_code = module.main()
+        self.assertEqual(exit_code, 0)
+        printed = print_mock.call_args[0][0]
+        self.assertEqual(json.loads(printed)["status"], "current")

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -25,9 +25,11 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
             "references/KERNEL_SYNC_POLICY.md",
+            "references/KERNEL_UPSTREAM_AWARENESS.md",
             "references/MODEL_ADAPTERS.md",
             "references/RESEARCH_POLICY.md",
             "references/GITHUB_DELIVERY.md",
+            "scripts/check_kernel_upstream.py",
         ):
             self.assertTrue((ROOT / rel).exists(), rel)
 
@@ -39,6 +41,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
         self.assertIn("execution_surface_policy", payload)
+        self.assertIn("kernel_upstream_awareness_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
         research_policy = payload["research_policy"]
         self.assertIn("slice_classification", research_policy)
@@ -58,9 +61,11 @@ class RepoKernelCanonTests(unittest.TestCase):
             "templates/project/CONTRIBUTING.md",
             "templates/project/CODE_OF_CONDUCT.md",
             "templates/project/SECURITY.md",
+            "templates/project/.kernel/upstream.json",
             "templates/project/.github/CODEOWNERS",
             "templates/project/.github/labels.yml",
             "templates/project/.github/pull_request_template.md",
+            "templates/project/scripts/check_kernel_upstream.py",
             "templates/project/scripts/sync_github_labels.py",
             "templates/project/docs/PRD_TEMPLATE.md",
         ):
@@ -170,15 +175,19 @@ class RepoKernelCanonTests(unittest.TestCase):
             "README.md",
             "SKILL.md",
             "references/KERNEL_SYNC_POLICY.md",
+            "references/KERNEL_UPSTREAM_AWARENESS.md",
             "references/BOOTSTRAP.md",
             "templates/project/AGENTS.md",
             "templates/project/CONTRIBUTING.md",
+            "templates/project/README.md",
             "templates/project/docs/PRD_TEMPLATE.md",
         ):
             content = (ROOT / rel).read_text(encoding="utf-8")
             self.assertIn("kernel", content.lower(), rel)
-            self.assertIn("kernel_sync_review", content, rel)
-            self.assertIn("Kernel Impact", content, rel)
+            self.assertIn("kernel_upstream_check", content, rel)
+            if rel != "references/KERNEL_UPSTREAM_AWARENESS.md":
+                self.assertIn("kernel_sync_review", content, rel)
+                self.assertIn("Kernel Impact", content, rel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a formal `kernel_upstream_check` protocol to the universal kernel
- pin downstream consumer repos to an explicit upstream kernel commit in `.kernel/upstream.json`
- materialize a local-first `scripts/check_kernel_upstream.py` in the kernel repo and in bootstrapped consumer repos

## Parent Context
- Epic: #14
- Task: #15

## Scope
- machine-readable kernel state
- kernel references and README/skill docs
- bootstrap templating and downstream metadata pinning
- consumer checker script
- regression tests

## Verification
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m py_compile scripts/bootstrap_project_kernel.py scripts/check_kernel_upstream.py templates/project/scripts/check_kernel_upstream.py scripts/sync_github_labels.py`
- `git diff --check`
- `python3 scripts/bootstrap_project_kernel.py --target /tmp/agent-kernel-upstream-check --apply --force`
- `python3 /tmp/agent-kernel-upstream-check/scripts/check_kernel_upstream.py --metadata /tmp/agent-kernel-upstream-check/.kernel/upstream.json --json`

## Rollback
- revert this PR to remove the upstream-awareness canon, metadata file, and checker script

Closes #15
