### PR TITLE
Add kernel fleet sweep protocol

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -6,6 +6,7 @@ purpose:
   - stop serious work from starting as chat-only improvisation
   - preserve PRD-first execution and GitHub issue decomposition across repositories
   - keep the shared process model-agnostic across GPT/Codex and Claude-style agents
+  - allow one operator machine to notice kernel drift across many consumer repos without blind auto-sync
 
 layers:
   minimal_core:
@@ -107,6 +108,9 @@ execution_surface_policy:
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
     - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
 
+optional_operator_layers:
+  - kernel_fleet_sweep_policy
+
 kernel_upstream_awareness_policy:
   protocol_name: kernel_upstream_check
   consumer_metadata_file: .kernel/upstream.json
@@ -128,6 +132,26 @@ kernel_upstream_awareness_policy:
     - kernel_adoption_remains_a_normal_project_local_slice_with_prd_issue_verification_and_merge
     - urgent_incident_work_may_defer_kernel_adoption_but_must_not_hide_the_drift
     - optional_operator_fleet_checks_may_call_the_same_protocol_across_multiple_repositories_but_are_not_bootstrap_default
+
+kernel_fleet_sweep_policy:
+  protocol_name: kernel_fleet_sweep
+  bootstrap_default: false
+  default_config_path: ~/.config/agent-engineering-kernel/fleet-repos.json
+  preferred_inputs:
+    - explicit_repo_paths
+    - operator_local_config_file
+  per_repo_statuses:
+    - current
+    - update_available
+    - not_configured
+    - unknown
+  rules:
+    - kernel_fleet_sweep_is_operator_local_and_optional
+    - prefer_consumer_repo_checker_when_present
+    - fallback_to_kernel_checker_with_consumer_metadata_when_consumer_checker_is_missing
+    - support_cli_repo_paths_and_config_file_repo_paths
+    - never_auto_apply_kernel_updates_from_fleet_sweep
+    - if_attention_is_found_turn_it_into_normal_project_local_adoption_work_or_documented_deferral
 
 kernel_sync_policy:
   protocol_name: kernel_sync_review

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository is the standalone source-of-truth for:
 - kernel sync review for promoting proven project learnings back into the universal kernel
 - optional GitHub Projects layer only when the repository actually needs shared planning views beyond issue-first execution
 - kernel upstream awareness so consumer repositories can detect kernel drift explicitly
+- optional kernel fleet sweep so one operator machine can review many consumer repos at once
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 
@@ -61,6 +62,7 @@ Kernel sync canon:
 - consumer repositories carry `.kernel/upstream.json` with an exact pinned kernel commit
 - if upstream differs from the pinned commit, the project records `update_available` and either opens/updates a project-local task or explicitly defers adoption
 - downstream repositories never auto-apply kernel changes blindly
+- operators may optionally run `kernel_fleet_sweep` locally to scan several consumer repos in one pass without changing bootstrap minimums
 - every serious slice ends with `kernel_sync_review`
 - `kernel_impact` must be classified as `none`, `project_local_only`, or `promote_to_kernel`
 - active PRDs and serious closeouts carry an explicit `Kernel Impact` decision
@@ -94,6 +96,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how kernel learnings are promoted without polluting the universal core
 - [references/KERNEL_UPSTREAM_AWARENESS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_UPSTREAM_AWARENESS.md)
   - how consumer repositories notice upstream kernel changes and decide whether to adopt them
+- [references/KERNEL_FLEET_SWEEP.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_FLEET_SWEEP.md)
+  - how one operator machine can scan several consumer repos for kernel drift
 - [references/RESEARCH_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/RESEARCH_POLICY.md)
   - how research works, including the repo-local versus external-contract boundary
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
@@ -108,6 +112,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - repo-managed label sync for the kernel repo itself
 - [scripts/check_kernel_upstream.py](/Users/raketa23/Work/Vs/agent-engineering-kernel/scripts/check_kernel_upstream.py)
   - local-first kernel drift check for consumer repositories
+- [scripts/kernel_fleet_sweep.py](/Users/raketa23/Work/Vs/agent-engineering-kernel/scripts/kernel_fleet_sweep.py)
+  - optional local multi-repo wrapper around `kernel_upstream_check`
 - [docs/agent-engineering-kernel-prd-2026-04-17.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/agent-engineering-kernel-prd-2026-04-17.md)
   - decision record for this repository
 - [docs/research-boundary-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/research-boundary-prd-2026-04-18.md)
@@ -144,6 +150,12 @@ Check whether a consumer project is behind the current kernel:
 
 ```bash
 python3 scripts/check_kernel_upstream.py --json
+```
+
+Optionally scan several consumer repos from one operator machine:
+
+```bash
+python3 scripts/kernel_fleet_sweep.py --json
 ```
 
 ## Validate this repository

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,7 @@ Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the use
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
 Read [references/KERNEL_UPSTREAM_AWARENESS.md](references/KERNEL_UPSTREAM_AWARENESS.md) when the user asks how consumer projects should notice upstream kernel changes and decide whether to adopt them.
+Read [references/KERNEL_FLEET_SWEEP.md](references/KERNEL_FLEET_SWEEP.md) when the user asks how one operator machine should check kernel drift across many consumer repositories at once.
 Read [references/GITHUB_DELIVERY.md](references/GITHUB_DELIVERY.md) when the user asks how branch/PR/merge flow should work end-to-end.
 Read [references/BUG_INTAKE.md](references/BUG_INTAKE.md) when the user asks how runtime failures should become GitHub `Bug` issues without noisy duplication.
 
@@ -34,7 +35,9 @@ The bug-intake rule is explicit:
 - establishing local-first execution and prerequisite bootstrap
 - establishing kernel sync review and kernel impact discipline
 - establishing kernel upstream awareness and downstream adoption checks
+- establishing optional multi-repo kernel fleet sweep on the operator machine
 - running the `kernel_upstream_check` protocol in consumer repositories
+- running the `kernel_fleet_sweep` protocol for multiple consumer repositories
 - running the `kernel_sync_review` closure protocol
 - establishing branch / draft PR / merge discipline
 - creating project-local canon files and templates

--- a/docs/kernel-fleet-sweep-prd-2026-04-18.md
+++ b/docs/kernel-fleet-sweep-prd-2026-04-18.md
@@ -1,0 +1,122 @@
+# PRD: Optional kernel fleet sweep for multi-repo operators
+
+Date: `2026-04-18`
+
+Status: `completed`
+
+Source evidence:
+
+- [kernel-upstream-awareness-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/kernel-upstream-awareness-prd-2026-04-18.md)
+
+## Problem
+
+`kernel_upstream_check` now gives deterministic drift awareness inside one consumer repository, but an operator working across several repositories still needs to enter each repo separately to run it. That is unnecessary operator friction and makes cross-project kernel drift easy to miss.
+
+## Research Basis
+
+- Slice classification: `repo_local_slice`
+- Tavily-first research used: `no`
+- Official docs used: `no`
+
+Why:
+
+- this slice extends already-verified kernel-owned local tooling
+- no new vendor or platform behavior is being asserted beyond the existing kernel upstream-awareness contract
+
+## Current State
+
+Verified facts only.
+
+- Kernel defines `kernel_upstream_check` and ships `scripts/check_kernel_upstream.py`.
+- Consumer repos can pin `.kernel/upstream.json` and detect `current | update_available | not_configured | unknown`.
+- Kernel docs already mention that an optional operator fleet sweep may exist.
+- Kernel does not yet ship a canonical fleet-level script, config format, or operator reference.
+
+## Target State
+
+- Kernel defines a formal optional `kernel_fleet_sweep` operator protocol.
+- Kernel ships a local-first script that scans multiple consumer repos in one pass.
+- The script reuses each consumer repo's own `scripts/check_kernel_upstream.py` when present.
+- The script supports both:
+  - explicit repo paths passed on the CLI
+  - a simple config file listing repo paths
+- Output is deterministic and machine-readable through `--json`.
+- The sweep remains read-only and non-destructive.
+
+## Write Scope
+
+- `SKILL.md`
+- `ENGINEERING_KERNEL.yaml`
+- `README.md`
+- `references/KERNEL_UPSTREAM_AWARENESS.md`
+- new `references/KERNEL_FLEET_SWEEP.md`
+- new `scripts/kernel_fleet_sweep.py`
+- `tests/test_check_kernel_upstream.py`
+- new `tests/test_kernel_fleet_sweep.py`
+- `tests/test_repo_kernel_canon.py`
+
+## Rollout
+
+### Phase 1
+- define the new protocol in kernel canon and docs
+- add a dedicated operator reference
+
+Validation:
+- docs mention `kernel_fleet_sweep`
+- machine-readable kernel parses
+
+### Phase 2
+- implement the local-first fleet sweep script
+- support CLI repo paths and config-file repo paths
+
+Validation:
+- script prints stable per-repo statuses
+- JSON output is deterministic
+
+### Phase 3
+- add regression coverage for config parsing and aggregation
+
+Validation:
+- targeted tests pass
+- script can scan a temp fleet with mixed statuses
+
+## Verification Matrix
+
+- code-path tests
+  - config parsing
+  - per-repo aggregation
+  - current / update_available / not_configured / unknown reporting
+- build/runtime checks
+  - `py_compile` on added scripts
+- sync checks
+  - sweep uses project-local `scripts/check_kernel_upstream.py` when available
+- live checks
+  - run sweep against at least the local kernel consumer repos on this Mac
+- rollback validation
+  - removing the sweep leaves `kernel_upstream_check` unchanged for single-repo use
+
+## Kernel Impact
+
+- `promote_to_kernel`
+
+Why:
+
+This is universal operator workflow canon for multi-project users of the shared engineering kernel.
+
+## Verification Snapshot
+
+- code-path tests
+  - `.venv/bin/python -m unittest tests.test_check_kernel_upstream tests.test_kernel_fleet_sweep tests.test_repo_kernel_canon` -> `OK`
+- build/runtime checks
+  - `python3 -m py_compile scripts/check_kernel_upstream.py scripts/kernel_fleet_sweep.py` -> `OK`
+- live/operator check
+  - `python3 scripts/kernel_fleet_sweep.py --json` -> `repo_count = 2`, `needs_attention_count = 2`
+  - both current local consumer repos are honestly `not_configured` today, which is valid fleet-sweep evidence rather than a hidden failure
+
+## Final State
+
+- kernel now defines the optional `kernel_fleet_sweep` protocol
+- kernel ships `scripts/kernel_fleet_sweep.py`
+- kernel ships `references/KERNEL_FLEET_SWEEP.md`
+- operator-local default config path is documented as `~/.config/agent-engineering-kernel/fleet-repos.json`
+- fleet sweep reuses consumer checkers when available and falls back to the kernel checker otherwise

--- a/references/KERNEL_FLEET_SWEEP.md
+++ b/references/KERNEL_FLEET_SWEEP.md
@@ -1,0 +1,96 @@
+# Kernel Fleet Sweep
+
+Use this reference when one operator machine needs a single view across multiple consumer repositories of `agent-engineering-kernel`.
+
+## Problem
+
+`kernel_upstream_check` already works per consumer repository, but operators with several active repos still need a multi-repo control point. `kernel_fleet_sweep` is that optional operator-local layer.
+
+## Canonical name
+
+- protocol: `kernel_fleet_sweep`
+
+This protocol does not replace `kernel_upstream_check`.
+
+- `kernel_upstream_check` is the per-repo drift check
+- `kernel_fleet_sweep` is the optional multi-repo wrapper around that same contract
+
+## Scope
+
+- operator-local only
+- read-only
+- optional
+- not a bootstrap default
+
+Do not turn this into blind auto-adoption.
+
+## Default config path
+
+- `~/.config/agent-engineering-kernel/fleet-repos.json`
+
+Accepted file shapes:
+
+1. JSON object:
+
+```json
+{
+  "repos": [
+    "/absolute/path/to/project-a",
+    "/absolute/path/to/project-b"
+  ]
+}
+```
+
+2. JSON array:
+
+```json
+[
+  "/absolute/path/to/project-a",
+  "/absolute/path/to/project-b"
+]
+```
+
+3. Plain text file:
+
+```text
+# one repo path per line
+/absolute/path/to/project-a
+/absolute/path/to/project-b
+```
+
+## Rules
+
+- prefer each consumer repo's own `scripts/check_kernel_upstream.py` when present
+- fall back to the kernel's `scripts/check_kernel_upstream.py` with the consumer repo's `.kernel/upstream.json` when the consumer checker is missing
+- support both explicit repo paths and config-file-driven repo discovery
+- never auto-apply kernel updates
+- if a repo reports `update_available`, turn it into a normal project-local adoption slice or explicitly defer it
+
+## Canonical statuses
+
+Per-repo status remains the same as `kernel_upstream_check`:
+
+- `current`
+- `update_available`
+- `not_configured`
+- `unknown`
+
+## Example
+
+Scan the default local fleet config:
+
+```bash
+python3 scripts/kernel_fleet_sweep.py --json
+```
+
+Scan explicit repos:
+
+```bash
+python3 scripts/kernel_fleet_sweep.py /path/to/repo-a /path/to/repo-b
+```
+
+Fail non-zero if any repo needs attention:
+
+```bash
+python3 scripts/kernel_fleet_sweep.py --fail-if-attention-required
+```

--- a/references/KERNEL_UPSTREAM_AWARENESS.md
+++ b/references/KERNEL_UPSTREAM_AWARENESS.md
@@ -55,8 +55,10 @@ Do not silently ignore the drift.
 
 ## Optional operator layer
 
-An operator machine may run a local scheduled sweep across many repositories and call the same checker in each consumer repo.
+An operator machine may run `kernel_fleet_sweep` locally across many repositories and call the same checker contract in each consumer repo.
 
 That fleet sweep is optional.
 
 It is not part of the bootstrap minimum because it depends on the operator's local topology.
+
+See [KERNEL_FLEET_SWEEP.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_FLEET_SWEEP.md).

--- a/scripts/kernel_fleet_sweep.py
+++ b/scripts/kernel_fleet_sweep.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CHECKER = ROOT / "scripts" / "check_kernel_upstream.py"
+DEFAULT_CONFIG = Path.home() / ".config" / "agent-engineering-kernel" / "fleet-repos.json"
+CANONICAL_STATUSES = ("current", "update_available", "not_configured", "unknown")
+
+
+def load_repo_paths_from_config(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8")
+    stripped = raw.strip()
+    if not stripped:
+        return []
+
+    if path.suffix.lower() == ".json" or stripped[0] in "[{":
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            repos = payload.get("repos", [])
+        elif isinstance(payload, list):
+            repos = payload
+        else:
+            raise ValueError(f"Unsupported config payload in {path}")
+        if not isinstance(repos, list):
+            raise ValueError(f"Expected 'repos' list in {path}")
+        return [str(item).strip() for item in repos if str(item).strip()]
+
+    paths: list[str] = []
+    for line in raw.splitlines():
+        candidate = line.strip()
+        if not candidate or candidate.startswith("#"):
+            continue
+        paths.append(candidate)
+    return paths
+
+
+def collect_repo_paths(cli_repos: list[str], config_path: Path | None) -> list[Path]:
+    ordered: list[Path] = []
+    seen: set[Path] = set()
+
+    candidates: list[str] = []
+    if config_path is not None and config_path.exists():
+        candidates.extend(load_repo_paths_from_config(config_path))
+    candidates.extend(cli_repos)
+
+    for repo in candidates:
+        resolved = Path(repo).expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(resolved)
+    return ordered
+
+
+def select_checker(repo_path: Path) -> tuple[Path, str]:
+    consumer_checker = repo_path / "scripts" / "check_kernel_upstream.py"
+    if consumer_checker.exists():
+        return consumer_checker, "consumer_repo"
+    return DEFAULT_CHECKER, "kernel_fallback"
+
+
+def run_checker(checker_path: Path, repo_path: Path, metadata_path: Path) -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(checker_path), "--metadata", str(metadata_path), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_path if repo_path.exists() else ROOT),
+    )
+    if completed.returncode != 0:
+        return {
+            "status": "unknown",
+            "error": completed.stderr.strip() or completed.stdout.strip() or "checker failed",
+        }
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "status": "unknown",
+            "error": f"invalid checker JSON: {exc}",
+        }
+    if not isinstance(payload, dict):
+        return {
+            "status": "unknown",
+            "error": "checker did not return a JSON object",
+        }
+    return payload
+
+
+def inspect_repo(repo_path: Path) -> dict:
+    if not repo_path.exists():
+        return {
+            "repo_path": str(repo_path),
+            "status": "unknown",
+            "error": "repo path does not exist",
+        }
+
+    metadata_path = repo_path / ".kernel" / "upstream.json"
+    checker_path, checker_source = select_checker(repo_path)
+    payload = run_checker(checker_path, repo_path, metadata_path)
+    result = dict(payload)
+    result["repo_path"] = str(repo_path)
+    result["metadata_path"] = str(metadata_path)
+    result["checker_path"] = str(checker_path)
+    result["checker_source"] = checker_source
+    if result.get("status") not in CANONICAL_STATUSES:
+        result["status"] = "unknown"
+        result.setdefault("error", "checker returned non-canonical status")
+    return result
+
+
+def summarize(results: list[dict]) -> dict[str, int]:
+    counts = {status: 0 for status in CANONICAL_STATUSES}
+    for result in results:
+        status = str(result.get("status") or "unknown")
+        if status not in counts:
+            status = "unknown"
+        counts[status] += 1
+    return counts
+
+
+def build_fleet_result(repo_paths: list[Path], config_path: Path | None) -> dict:
+    results = [inspect_repo(path) for path in repo_paths]
+    counts = summarize(results)
+    return {
+        "repo_count": len(results),
+        "needs_attention_count": sum(count for status, count in counts.items() if status != "current"),
+        "status_counts": counts,
+        "config_path": str(config_path) if config_path is not None and config_path.exists() else None,
+        "repos": results,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run kernel_upstream_check across multiple consumer repositories.")
+    parser.add_argument("repos", nargs="*", help="Explicit repository paths to scan.")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG),
+        help="Optional config file listing repository paths. Defaults to ~/.config/agent-engineering-kernel/fleet-repos.json",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON output.")
+    parser.add_argument(
+        "--fail-if-attention-required",
+        action="store_true",
+        help="Exit non-zero when any repository is not current.",
+    )
+    return parser
+
+
+def render_text(result: dict) -> str:
+    lines = [
+        f"repo_count: {result['repo_count']}",
+        f"needs_attention_count: {result['needs_attention_count']}",
+    ]
+    for status in CANONICAL_STATUSES:
+        lines.append(f"{status}: {result['status_counts'][status]}")
+    if result.get("config_path"):
+        lines.append(f"config_path: {result['config_path']}")
+    for repo in result["repos"]:
+        lines.append(f"- [{repo['status']}] {repo['repo_path']}")
+        lines.append(f"  checker_source: {repo['checker_source']}")
+        if "pinned_commit" in repo:
+            lines.append(f"  pinned_commit: {repo['pinned_commit']}")
+        if "remote_commit" in repo:
+            lines.append(f"  remote_commit: {repo['remote_commit']}")
+        if repo.get("error"):
+            lines.append(f"  error: {repo['error']}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    config_path = Path(args.config).expanduser().resolve() if args.config else None
+    repo_paths = collect_repo_paths(args.repos, config_path)
+    if not repo_paths:
+        raise SystemExit("No repositories configured. Pass repo paths or provide a config file.")
+
+    result = build_fleet_result(repo_paths, config_path)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(render_text(result))
+
+    if args.fail_if_attention_required and result["needs_attention_count"] > 0:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kernel_fleet_sweep.py
+++ b/tests/test_kernel_fleet_sweep.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "kernel_fleet_sweep.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("kernel_fleet_sweep_module", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class KernelFleetSweepTests(unittest.TestCase):
+    def test_load_repo_paths_from_json_mapping(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "fleet-repos.json"
+            config.write_text(json.dumps({"repos": ["/tmp/a", "/tmp/b"]}), encoding="utf-8")
+            repos = module.load_repo_paths_from_config(config)
+        self.assertEqual(repos, ["/tmp/a", "/tmp/b"])
+
+    def test_load_repo_paths_from_plain_text_ignores_comments(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "fleet-repos.txt"
+            config.write_text("# comment\n\n/tmp/a\n/tmp/b\n", encoding="utf-8")
+            repos = module.load_repo_paths_from_config(config)
+        self.assertEqual(repos, ["/tmp/a", "/tmp/b"])
+
+    def test_select_checker_prefers_consumer_repo_script(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            scripts_dir = repo / "scripts"
+            scripts_dir.mkdir()
+            checker = scripts_dir / "check_kernel_upstream.py"
+            checker.write_text("print('ok')\n", encoding="utf-8")
+            selected, source = module.select_checker(repo)
+        self.assertEqual(selected, checker)
+        self.assertEqual(source, "consumer_repo")
+
+    def test_build_fleet_result_aggregates_status_counts(self) -> None:
+        module = load_module()
+        repos = [Path("/tmp/a"), Path("/tmp/b"), Path("/tmp/c")]
+        with mock.patch.object(
+            module,
+            "inspect_repo",
+            side_effect=[
+                {"repo_path": "/tmp/a", "status": "current", "checker_source": "consumer_repo"},
+                {"repo_path": "/tmp/b", "status": "update_available", "checker_source": "consumer_repo"},
+                {"repo_path": "/tmp/c", "status": "unknown", "checker_source": "kernel_fallback", "error": "boom"},
+            ],
+        ):
+            result = module.build_fleet_result(repos, None)
+        self.assertEqual(result["repo_count"], 3)
+        self.assertEqual(result["needs_attention_count"], 2)
+        self.assertEqual(result["status_counts"]["current"], 1)
+        self.assertEqual(result["status_counts"]["update_available"], 1)
+        self.assertEqual(result["status_counts"]["unknown"], 1)
+
+    def test_main_returns_nonzero_when_attention_required(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            with mock.patch.object(
+                module,
+                "build_fleet_result",
+                return_value={
+                    "repo_count": 1,
+                    "needs_attention_count": 1,
+                    "status_counts": {
+                        "current": 0,
+                        "update_available": 1,
+                        "not_configured": 0,
+                        "unknown": 0,
+                    },
+                    "config_path": None,
+                    "repos": [
+                        {
+                            "repo_path": str(repo),
+                            "status": "update_available",
+                            "checker_source": "consumer_repo",
+                            "pinned_commit": "abc",
+                            "remote_commit": "def",
+                        }
+                    ],
+                },
+            ):
+                with mock.patch.object(module, "collect_repo_paths", return_value=[repo]):
+                    with mock.patch("sys.argv", ["kernel_fleet_sweep.py", str(repo), "--fail-if-attention-required"]):
+                        with mock.patch("builtins.print"):
+                            exit_code = module.main()
+        self.assertEqual(exit_code, 2)

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -24,12 +24,14 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/BOOTSTRAP.md",
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
+            "references/KERNEL_FLEET_SWEEP.md",
             "references/KERNEL_SYNC_POLICY.md",
             "references/KERNEL_UPSTREAM_AWARENESS.md",
             "references/MODEL_ADAPTERS.md",
             "references/RESEARCH_POLICY.md",
             "references/GITHUB_DELIVERY.md",
             "scripts/check_kernel_upstream.py",
+            "scripts/kernel_fleet_sweep.py",
         ):
             self.assertTrue((ROOT / rel).exists(), rel)
 
@@ -41,7 +43,9 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
         self.assertIn("execution_surface_policy", payload)
+        self.assertIn("optional_operator_layers", payload)
         self.assertIn("kernel_upstream_awareness_policy", payload)
+        self.assertIn("kernel_fleet_sweep_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
         research_policy = payload["research_policy"]
         self.assertIn("slice_classification", research_policy)
@@ -188,6 +192,16 @@ class RepoKernelCanonTests(unittest.TestCase):
             if rel != "references/KERNEL_UPSTREAM_AWARENESS.md":
                 self.assertIn("kernel_sync_review", content, rel)
                 self.assertIn("Kernel Impact", content, rel)
+
+    def test_kernel_docs_mention_kernel_fleet_sweep(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/KERNEL_UPSTREAM_AWARENESS.md",
+            "references/KERNEL_FLEET_SWEEP.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("kernel_fleet_sweep", content, rel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the optional `kernel_fleet_sweep` protocol, docs, and local script
- add regression coverage for config parsing and multi-repo aggregation
- document and validate the live operator config path on this Mac

## Parent
- Epic: #17

## Closes
- Closes #18

## Verification
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m py_compile scripts/check_kernel_upstream.py scripts/kernel_fleet_sweep.py`
- `python3 scripts/kernel_fleet_sweep.py --json`
