### PR TITLE
Add canonical kernel adoption task

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -15,6 +15,7 @@ layers:
     - research_policy
     - execution_surface_policy
     - kernel_upstream_awareness_policy
+    - kernel_adoption_task_policy
     - kernel_sync_policy
     - github_issue_tree
     - automatic_bug_intake
@@ -132,6 +133,31 @@ kernel_upstream_awareness_policy:
     - kernel_adoption_remains_a_normal_project_local_slice_with_prd_issue_verification_and_merge
     - urgent_incident_work_may_defer_kernel_adoption_but_must_not_hide_the_drift
     - optional_operator_fleet_checks_may_call_the_same_protocol_across_multiple_repositories_but_are_not_bootstrap_default
+
+kernel_adoption_task_policy:
+  work_item_name: kernel_adoption_task
+  issue_type: Task
+  trigger_status:
+    - update_available
+  canonical_decisions:
+    - adopt_now
+    - defer
+    - not_applicable
+  required_fields:
+    - target_upstream_commit
+    - current_pinned_commit
+    - kernel_delta_reference
+    - decision
+    - local_write_scope
+    - verification_plan
+  rules:
+    - if_kernel_upstream_check_reports_update_available_open_or_update_one_kernel_adoption_task_unless_the_active_slice_explicitly_defers_adoption
+    - kernel_adoption_task_is_the_canonical_downstream_work_item_name_for_kernel_updates
+    - kernel_adoption_task_must_record_a_decision_of_adopt_now_defer_or_not_applicable
+    - kernel_adoption_task_must_capture_target_commit_current_pin_delta_summary_and_verification_plan
+    - advance_dot_kernel_upstream_json_only_after_adoption_is_implemented_and_verified
+    - defer_and_not_applicable_decisions_must_record_why_and_when_to_revisit
+    - do_not_spawn_duplicate_kernel_adoption_tasks_for_the_same_unresolved_kernel_delta
 
 kernel_fleet_sweep_policy:
   protocol_name: kernel_fleet_sweep

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository is the standalone source-of-truth for:
 - kernel sync review for promoting proven project learnings back into the universal kernel
 - optional GitHub Projects layer only when the repository actually needs shared planning views beyond issue-first execution
 - kernel upstream awareness so consumer repositories can detect kernel drift explicitly
+- a canonical `kernel_adoption_task` so downstream repos handle kernel drift deterministically
 - optional kernel fleet sweep so one operator machine can review many consumer repos at once
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
@@ -60,7 +61,12 @@ Kernel sync canon:
 
 - every serious consumer-project slice begins with `kernel_upstream_check`
 - consumer repositories carry `.kernel/upstream.json` with an exact pinned kernel commit
-- if upstream differs from the pinned commit, the project records `update_available` and either opens/updates a project-local task or explicitly defers adoption
+- if upstream differs from the pinned commit, the project records `update_available` and either opens/updates a `kernel_adoption_task` or explicitly defers adoption
+- `kernel_adoption_task` records one decision:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
+- `.kernel/upstream.json` only advances after adoption is implemented and verified
 - downstream repositories never auto-apply kernel changes blindly
 - operators may optionally run `kernel_fleet_sweep` locally to scan several consumer repos in one pass without changing bootstrap minimums
 - every serious slice ends with `kernel_sync_review`
@@ -96,6 +102,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how kernel learnings are promoted without polluting the universal core
 - [references/KERNEL_UPSTREAM_AWARENESS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_UPSTREAM_AWARENESS.md)
   - how consumer repositories notice upstream kernel changes and decide whether to adopt them
+- [references/KERNEL_ADOPTION_TASK.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_ADOPTION_TASK.md)
+  - exact downstream `Task` shape for adopting, deferring, or rejecting a kernel update
 - [references/KERNEL_FLEET_SWEEP.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_FLEET_SWEEP.md)
   - how one operator machine can scan several consumer repos for kernel drift
 - [references/RESEARCH_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/RESEARCH_POLICY.md)
@@ -118,6 +126,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - decision record for this repository
 - [docs/research-boundary-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/research-boundary-prd-2026-04-18.md)
   - decision record for the research-boundary classification rule
+- [docs/kernel-adoption-task-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/kernel-adoption-task-prd-2026-04-18.md)
+  - decision record for the canonical downstream kernel adoption task
 
 ## Bootstrap a project
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,7 @@ Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the use
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
 Read [references/KERNEL_UPSTREAM_AWARENESS.md](references/KERNEL_UPSTREAM_AWARENESS.md) when the user asks how consumer projects should notice upstream kernel changes and decide whether to adopt them.
+Read [references/KERNEL_ADOPTION_TASK.md](references/KERNEL_ADOPTION_TASK.md) when the user asks what exact downstream `Task` should be opened or updated after `kernel_upstream_check` reports drift.
 Read [references/KERNEL_FLEET_SWEEP.md](references/KERNEL_FLEET_SWEEP.md) when the user asks how one operator machine should check kernel drift across many consumer repositories at once.
 Read [references/GITHUB_DELIVERY.md](references/GITHUB_DELIVERY.md) when the user asks how branch/PR/merge flow should work end-to-end.
 Read [references/BUG_INTAKE.md](references/BUG_INTAKE.md) when the user asks how runtime failures should become GitHub `Bug` issues without noisy duplication.
@@ -35,6 +36,7 @@ The bug-intake rule is explicit:
 - establishing local-first execution and prerequisite bootstrap
 - establishing kernel sync review and kernel impact discipline
 - establishing kernel upstream awareness and downstream adoption checks
+- establishing the canonical `kernel_adoption_task` work item for downstream kernel updates
 - establishing optional multi-repo kernel fleet sweep on the operator machine
 - running the `kernel_upstream_check` protocol in consumer repositories
 - running the `kernel_fleet_sweep` protocol for multiple consumer repositories

--- a/docs/kernel-adoption-task-prd-2026-04-18.md
+++ b/docs/kernel-adoption-task-prd-2026-04-18.md
@@ -1,0 +1,138 @@
+# PRD: Canonical Kernel Adoption Task
+
+Date: `2026-04-18`
+
+Status: `completed`
+
+## Problem
+
+The kernel already defines `kernel_upstream_check`, but downstream repos only know that they should open or update a project-local `Task` when the checker reports `update_available`. The kernel does not yet define the exact canonical shape of that work item. Without a stable name, decision model, and checklist, downstream adoption drifts into free-form prose and inconsistent verification.
+
+## Research Basis
+
+- slice classification: `repo_local_slice`
+- external Tavily research used: `no`
+- official docs used: `no`
+- live runtime evidence used: `yes`
+
+Why:
+
+This slice changes the internal engineering kernel only. The source of truth is the existing kernel canon, current consumer-repo behavior, and current fleet-sweep output. No vendor or external API contract is changing.
+
+## Current State
+
+Verified facts only:
+
+- The kernel already defines `kernel_upstream_check`, `.kernel/upstream.json`, and the statuses `current | update_available | not_configured | unknown`.
+- The kernel already states that downstream repos must open or update a project-local `Task` or explicitly defer adoption when `update_available` is reported.
+- The kernel does not yet define a canonical task name, canonical decision values, or a required checklist for that adoption task.
+- Current consumer repos (`dudarik.com`, `yotubol`) therefore only carry the generic wording about “open or update a Task”.
+
+## Target State
+
+- The kernel defines a canonical downstream work item name: `kernel_adoption_task`.
+- The kernel defines canonical decisions for that task:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
+- The kernel defines the minimum required fields/checklist for the task:
+  - target upstream commit
+  - linked kernel delta summary/reference
+  - decision
+  - exact local write scope
+  - verification plan
+  - `.kernel/upstream.json` update rule
+  - defer reason and review trigger when deferred
+- Kernel references, templates, and tests encode this canon.
+- Active consumer repos inherit the same canon in their local docs.
+
+## Write Scope
+
+- `ENGINEERING_KERNEL.yaml`
+- `SKILL.md`
+- `README.md`
+- `references/KERNEL_UPSTREAM_AWARENESS.md`
+- `references/GITHUB_DELIVERY.md`
+- new reference for the adoption task canon
+- `templates/project/README.md`
+- `templates/project/AGENTS.md`
+- `templates/project/CONTRIBUTING.md`
+- `templates/project/docs/PRD_TEMPLATE.md`
+- kernel tests
+- consumer repo docs/tests needed to keep active repos aligned
+
+## Rollout
+
+### Phase 1: Kernel canon
+
+Entry condition:
+- active PRD exists
+
+Actions:
+- add the canonical `kernel_adoption_task` rules to the kernel
+- add a dedicated reference doc
+- update templates and machine-readable kernel state
+- add regressions
+
+Validation:
+- kernel unit tests
+- template/bootstrap related tests
+
+Success condition:
+- kernel repo contains a stable canon for downstream adoption tasks
+
+Rollback trigger:
+- tests fail or the canon conflicts with the existing upstream-awareness protocol
+
+### Phase 2: Consumer sync
+
+Entry condition:
+- kernel Phase 1 merged locally and green
+
+Actions:
+- sync the new adoption-task canon into active consumer repos
+- add project-local regressions where needed
+
+Validation:
+- project-local canon tests
+- local `check_kernel_upstream.py --json`
+- local fleet sweep
+
+Success condition:
+- active consumers mention the canonical adoption-task contract and still report `current`
+
+Rollback trigger:
+- consumer docs/tests drift or fleet sweep regresses from `current`
+
+## Verification Matrix
+
+- code-path tests:
+  - kernel canon tests
+  - consumer canon tests
+- build/runtime checks:
+  - `python3 -m py_compile` for touched scripts if any
+- source-of-truth / sync checks:
+  - consumer `.kernel/upstream.json` still parses
+  - fleet sweep still reports expected statuses
+- live checks:
+  - per-consumer `scripts/check_kernel_upstream.py --json`
+  - operator `kernel_fleet_sweep.py --json`
+- rollback validation:
+  - remove the new canon and verify existing upstream-awareness behavior still stands if rollback is required
+
+## Kernel Impact
+
+- `promote_to_kernel`
+
+Why:
+
+This slice defines a reusable downstream-adoption workflow that every kernel consumer can share.
+
+## Closure
+
+- kernel now defines the canonical downstream work item `kernel_adoption_task`
+- canonical decisions are fixed as `adopt_now | defer | not_applicable`
+- kernel references, templates, and tests were updated accordingly
+- verification passed:
+  - `.venv/bin/python -m unittest discover -s tests`
+  - `python3 -m py_compile scripts/check_kernel_upstream.py scripts/kernel_fleet_sweep.py scripts/bootstrap_project_kernel.py`

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -30,7 +30,11 @@ Execution-surface rule:
 - prefer squash merge unless the project canon explicitly chooses another method
 - automatic bug intake opens or updates the `Bug` issue before the fix slice starts
 - repeated incidents should update the existing bug issue for the same fingerprint instead of spawning duplicates
-- if `kernel_upstream_check` reports `update_available`, open or update a project-local `Task` unless the active slice explicitly documents a deferral
+- if `kernel_upstream_check` reports `update_available`, open or update a `kernel_adoption_task` unless the active slice explicitly documents a deferral
+- `kernel_adoption_task` should record one decision:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
 - when using `gh issue create`, `gh issue edit`, or `gh pr create` from shell, prefer `--body-file` over inline `--body`
 - never embed markdown with backticks or fenced code blocks in inline double-quoted `gh --body` arguments
 - acceptable fallback is a single-quoted heredoc such as `<<'EOF'` that writes the body file first

--- a/references/KERNEL_ADOPTION_TASK.md
+++ b/references/KERNEL_ADOPTION_TASK.md
@@ -1,0 +1,63 @@
+# Canonical Kernel Adoption Task
+
+Use this reference when a consumer repository reports `update_available` from `kernel_upstream_check`.
+
+## Problem
+
+Knowing that the kernel changed is not enough. Downstream repositories need one deterministic work-item shape for deciding whether and how to adopt that update.
+
+## Canonical names
+
+- work item: `kernel_adoption_task`
+- issue type: `Task`
+
+This is not a new top-level protocol. It is the canonical downstream work item triggered by `kernel_upstream_check` when adoption work is needed.
+
+## Canonical decisions
+
+- `adopt_now`
+- `defer`
+- `not_applicable`
+
+## Required fields
+
+Every `kernel_adoption_task` should capture:
+
+- the target upstream kernel commit
+- the current pinned downstream commit
+- the kernel delta summary or reference link
+- the chosen decision
+- the exact local write scope if adoption happens now
+- the verification plan
+
+## Required rules
+
+- if `kernel_upstream_check` reports `update_available`, open or update one `kernel_adoption_task` in the consumer repo unless the active slice explicitly defers adoption
+- the task should remain one durable downstream tracker for that kernel delta, not a stream of duplicates
+- `.kernel/upstream.json` advances only after the adoption slice is implemented and verified
+- if the decision is `defer`, record:
+  - why the update is deferred
+  - what future trigger should cause re-review
+- if the decision is `not_applicable`, record why the kernel delta does not apply to this repository
+
+## Minimum checklist
+
+- compare the consumer's pinned commit with the target upstream commit
+- identify which kernel files/rules changed
+- decide `adopt_now | defer | not_applicable`
+- if adopting now:
+  - update local docs/scripts/templates as needed
+  - update `.kernel/upstream.json`
+  - verify locally
+- if deferring or marking not applicable:
+  - leave `.kernel/upstream.json` unchanged
+  - document the reason in the task or active PRD/closeout
+
+## Relationship to other kernel flows
+
+- `kernel_upstream_check`
+  - detects drift at slice start
+- `kernel_adoption_task`
+  - tracks the downstream decision and implementation work when drift matters
+- `kernel_sync_review`
+  - decides whether a finished project slice should promote new learning back into the kernel

--- a/references/KERNEL_UPSTREAM_AWARENESS.md
+++ b/references/KERNEL_UPSTREAM_AWARENESS.md
@@ -36,6 +36,7 @@ Do not treat template generation time as implicit truth.
 - downstream projects must not auto-apply kernel changes blindly
 - kernel adoption remains an explicit project-local slice with PRD, issue tree, verification, and merge
 - urgent incident work is not blocked by an available kernel update, but the drift must be recorded or turned into a project-local task
+- the canonical downstream task name is `kernel_adoption_task`
 
 ## Canonical statuses
 
@@ -48,10 +49,16 @@ Do not treat template generation time as implicit truth.
 
 If `kernel_upstream_check` reports `update_available`:
 
-- open or update a project-local `Task` issue to review/adopt the kernel update
+- open or update a `kernel_adoption_task` issue in the consumer repo to review/adopt the kernel update
 - or explicitly defer the adoption in the active PRD/closeout
+- the downstream decision model is:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
 
 Do not silently ignore the drift.
+
+See [KERNEL_ADOPTION_TASK.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_ADOPTION_TASK.md) for the exact downstream task shape and decisions.
 
 ## Optional operator layer
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -33,7 +33,12 @@ This repository follows the agent engineering kernel.
 
 - every serious slice begins with `kernel_upstream_check`
 - consumer metadata lives in `.kernel/upstream.json`
-- if `kernel_upstream_check` reports `update_available`, open or update a project-local `Task` or explicitly defer adoption in the active PRD/closeout
+- if `kernel_upstream_check` reports `update_available`, open or update a `kernel_adoption_task` or explicitly defer adoption in the active PRD/closeout
+- `kernel_adoption_task` records one decision:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
+- `.kernel/upstream.json` advances only after the adoption slice is implemented and verified
 - downstream repos do not auto-apply kernel changes blindly
 - every serious slice ends with `kernel_sync_review`
 - record `Kernel Impact` as one of:

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -41,7 +41,10 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 
 - every serious slice should begin with `kernel_upstream_check`
 - consumer kernel metadata lives in `.kernel/upstream.json`
-- if upstream kernel drift exists, open or update a project-local `Task` or explicitly defer it in the active PRD/closeout
+- if upstream kernel drift exists, open or update a `kernel_adoption_task` or explicitly defer it in the active PRD/closeout
+- the canonical downstream task is `kernel_adoption_task`
+- `kernel_adoption_task` records `adopt_now | defer | not_applicable`
+- `.kernel/upstream.json` advances only after adoption is implemented and verified
 - do not auto-apply kernel changes blindly into the project
 - every serious slice must end with `kernel_sync_review`
 - record `Kernel Impact` as:

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -19,6 +19,12 @@ This repository follows the agent engineering kernel.
 - GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
 - serious slices begin with `kernel_upstream_check`
 - the project pins its upstream kernel commit in `.kernel/upstream.json`
+- if drift exists, open or update a `kernel_adoption_task`
+- `kernel_adoption_task` records one decision:
+  - `adopt_now`
+  - `defer`
+  - `not_applicable`
+- `.kernel/upstream.json` only advances after adoption is implemented and verified
 - kernel updates are adopted explicitly through normal project issues/PRDs, not auto-applied blindly
 - every serious slice ends with `kernel_sync_review`
 - serious closeouts record `Kernel Impact`

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -27,6 +27,8 @@ Record near slice start.
 - protocol: `kernel_upstream_check`
 - status: `current | update_available | not_configured | unknown`
 - action: `none | task_opened_or_updated | explicitly_deferred`
+- `kernel_adoption_task`: `<issue id or n/a>`
+- adoption decision when drift exists: `adopt_now | defer | not_applicable`
 
 ## Rollout
 

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -27,6 +27,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/KERNEL_FLEET_SWEEP.md",
             "references/KERNEL_SYNC_POLICY.md",
             "references/KERNEL_UPSTREAM_AWARENESS.md",
+            "references/KERNEL_ADOPTION_TASK.md",
             "references/MODEL_ADAPTERS.md",
             "references/RESEARCH_POLICY.md",
             "references/GITHUB_DELIVERY.md",
@@ -45,6 +46,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("execution_surface_policy", payload)
         self.assertIn("optional_operator_layers", payload)
         self.assertIn("kernel_upstream_awareness_policy", payload)
+        self.assertIn("kernel_adoption_task_policy", payload)
         self.assertIn("kernel_fleet_sweep_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
         research_policy = payload["research_policy"]
@@ -202,6 +204,22 @@ class RepoKernelCanonTests(unittest.TestCase):
         ):
             content = (ROOT / rel).read_text(encoding="utf-8")
             self.assertIn("kernel_fleet_sweep", content, rel)
+
+    def test_kernel_docs_and_templates_mention_kernel_adoption_task(self) -> None:
+        for rel in (
+            "README.md",
+            "references/KERNEL_UPSTREAM_AWARENESS.md",
+            "references/KERNEL_ADOPTION_TASK.md",
+            "references/GITHUB_DELIVERY.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("kernel_adoption_task", content, rel)
+            self.assertIn("adopt_now", content, rel)
+            self.assertIn("defer", content, rel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Define the canonical `kernel_adoption_task` downstream workflow for kernel drift detected by `kernel_upstream_check`.

## Parent
- #20

## Leaf
- Closes #21

## Verification
- `.venv/bin/python -m unittest discover -s tests`
- `python3 -m py_compile scripts/check_kernel_upstream.py scripts/kernel_fleet_sweep.py scripts/bootstrap_project_kernel.py`
