### PR TITLE
Add external source-of-truth matrix canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -81,6 +81,16 @@ research_policy:
       - vendor_or_platform_behavior_claims
       - external_auth_or_api_contract_claims
       - interpreter_or_dependency_compatibility_claims
+  external_source_of_truth_matrix:
+    required_for:
+      - external_contract_slice
+    required_fields:
+      - surface_name
+      - project_local_source_of_truth
+      - upstream_or_vendor_source
+      - exact_version_commit_build_url_or_identifier
+      - local_verification_method
+      - divergence_notes
   rules:
     - research_is_tavily_first
     - classify_each_non_trivial_slice_as_repo_local_or_external_contract_before_edits
@@ -89,6 +99,9 @@ research_policy:
     - use_official_vendor_docs_for_external_contracts
     - distinguish_verified_facts_from_assumptions
     - external_contract_slice_evidence_must_be_recorded_in_the_active_prd_or_decision_note
+    - every_external_contract_slice_must_record_an_external_source_of_truth_matrix_before_implementation_lands
+    - reconcile_project_local_pins_vendor_docs_and_live_behavior_inside_the_external_source_of_truth_matrix
+    - if_repo_local_artifacts_conflict_with_fresh_vendor_docs_or_live_verification_the_conflict_must_be_explicitly_recorded_not_implicitly_ignored
     - if_known_url_exists_fetch_it_directly_instead_of_re-searching_blindly
     - if_primary_tool_is_unavailable_record_the_gap_and_use_the_best_documented_fallback
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Research canon:
 - classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
 - `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
 - `external_contract_slice` requires fresh external research before code or docs land
+- every `external_contract_slice` records an `external_source_of_truth_matrix` in the active PRD or decision note
 - official docs for external contracts
 - known URLs fetched directly when already available
 
@@ -109,6 +110,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how one operator machine can scan several consumer repos for kernel drift
 - [references/RESEARCH_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/RESEARCH_POLICY.md)
   - how research works, including the repo-local versus external-contract boundary
+- [docs/external-source-of-truth-matrix-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/external-source-of-truth-matrix-prd-2026-04-18.md)
+  - decision record for explicit version/source-of-truth reconciliation inside external-contract slices
 - [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
   - how branch/PR/merge flow should work end-to-end
 - [references/BUG_INTAKE.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/BUG_INTAKE.md)

--- a/docs/external-source-of-truth-matrix-prd-2026-04-18.md
+++ b/docs/external-source-of-truth-matrix-prd-2026-04-18.md
@@ -1,0 +1,83 @@
+# PRD: External Source-Of-Truth Matrix For External-Contract Slices
+
+Date: `2026-04-18`
+
+Status: `active`
+
+## Problem
+
+The kernel already distinguishes `repo_local_slice` from `external_contract_slice` and already requires fresh research for external-contract work.
+
+That is necessary but not sufficient.
+
+An agent can still do all of the following and ship the wrong thing:
+
+- classify the slice correctly;
+- read fresh vendor docs;
+- forget the repo's current pinned version or local source-of-truth file;
+- revive a stale helper or old project note that no longer matches the active external contract.
+
+This is the exact failure class behind stale dependency/version/login assumptions. The missing layer is a small explicit matrix that reconciles project truth, upstream truth, exact active version or identifier, and live verification before implementation lands.
+
+## Current State
+
+Verified facts only:
+
+- kernel canon already requires `external_contract_slice` classification and fresh external research;
+- kernel canon already requires evidence to be recorded in the active PRD or decision note;
+- kernel canon does not yet require one canonical structure that records the exact external surfaces in scope with their source-of-truth fields and pinned identifiers.
+
+## Target State
+
+For every `external_contract_slice`, the active PRD or decision note must record an `external_source_of_truth_matrix`.
+
+The matrix must explicitly capture, per external surface in scope:
+
+- the surface name;
+- the project-local source-of-truth file, pin, or config;
+- the current upstream/vendor source;
+- the exact active version, commit, build, URL, identifier, or contract revision;
+- the local verification method used to confirm current reality;
+- any known divergence between project-local truth, vendor docs, and live behavior.
+
+## Write Scope
+
+- `ENGINEERING_KERNEL.yaml`
+- `README.md`
+- `references/RESEARCH_POLICY.md`
+- `references/BOOTSTRAP.md`
+- `templates/project/README.md`
+- `templates/project/AGENTS.md`
+- `templates/project/CONTRIBUTING.md`
+- `templates/project/docs/PRD_TEMPLATE.md`
+- `tests/test_repo_kernel_canon.py`
+
+## Rollout
+
+1. Add `external_source_of_truth_matrix` to the machine-readable kernel under research policy.
+2. Update narrative kernel docs to explain when the matrix is mandatory and what it must contain.
+3. Update project templates so bootstrapped repos inherit the rule.
+4. Update the PRD template so the matrix has an explicit home instead of staying only in prose.
+5. Add regression coverage for the new canon.
+
+## Verification Matrix
+
+- code-path tests:
+  - `.venv/bin/python -m unittest tests.test_repo_kernel_canon`
+- build/runtime checks:
+  - `python3 -m py_compile scripts/*.py`
+- source-of-truth / sync checks:
+  - `git diff --check`
+  - docs/templates mention `external_source_of_truth_matrix`
+- live checks:
+  - none; this is a kernel-process slice
+- rollback validation:
+  - removing the new matrix requirement would leave the existing research-boundary rule intact but would re-open stale-version/source-of-truth drift
+
+## Kernel Impact
+
+- `none`
+
+Why:
+
+This slice updates the universal kernel itself rather than promoting a project-local learning to another higher layer.

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -42,6 +42,7 @@ The bootstrapped canon should also make explicit:
 - that each serious slice ends with `kernel_sync_review`
 - that active PRDs and closeouts carry a `Kernel Impact` decision
 - that the consumer project pins the exact kernel commit it bootstrapped from
+- that every `external_contract_slice` records an explicit `external_source_of_truth_matrix` in the active PRD or decision note
 
 ## How to use the templates
 

--- a/references/RESEARCH_POLICY.md
+++ b/references/RESEARCH_POLICY.md
@@ -17,6 +17,7 @@ The kernel is research-first, not guess-first.
 - for vendor/platform/API behavior, verify the external contract from official docs
 - separate verified facts from assumptions
 - record external-contract evidence in the active PRD or decision note instead of leaving it only in chat
+- every `external_contract_slice` must record an `external_source_of_truth_matrix` before implementation lands
 - if a known URL already exists, fetch or index it directly instead of re-running broad search
 - if Tavily or the preferred stack is unavailable, record the capability gap and use the best documented fallback
 
@@ -39,6 +40,27 @@ The boundary exists to prevent two opposite mistakes:
 
 - over-researching a pure repo-local slice as if it were an upstream-contract change
 - shipping an external-contract slice from stale memory or old assumptions
+
+## External source-of-truth matrix
+
+For every `external_contract_slice`, the active PRD or decision note must record an `external_source_of_truth_matrix`.
+
+Required fields per external surface in scope:
+
+- `surface_name`
+- `project_local_source_of_truth`
+- `upstream_or_vendor_source`
+- `exact_version_commit_build_url_or_identifier`
+- `local_verification_method`
+- `divergence_notes`
+
+The point is simple:
+
+- do not rely only on a fresh vendor doc if the project has a pinned local version or config
+- do not rely only on a local helper or old note if the current vendor contract has changed
+- do not let the exact active version/commit/build/URL stay implicit
+
+The matrix is where those facts are reconciled before implementation lands.
 
 ## What research should produce
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -17,6 +17,7 @@ This repository follows the agent engineering kernel.
 - classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
 - `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
 - `external_contract_slice` requires fresh external research before code or docs land
+- every `external_contract_slice` must record an `external_source_of_truth_matrix` in the active PRD or decision note before implementation lands
 - use official vendor docs to verify external contracts
 - if a known URL already exists, fetch/index it directly instead of re-running broad search
 - distinguish verified facts from assumptions

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -8,6 +8,7 @@ This repository uses a PRD-first and issue-first engineering workflow.
 - classify each non-trivial slice before edits as `repo_local_slice` or `external_contract_slice`
 - `repo_local_slice` may proceed from project truth, deterministic verification, and local runtime checks when only repo-owned behavior is changing
 - `external_contract_slice` requires fresh external research before code or docs land
+- every `external_contract_slice` must record an `external_source_of_truth_matrix` in the active PRD or decision note before implementation lands
 - official docs for external contracts
 - known URLs should be fetched/indexed directly when available
 - verified facts must be separated from assumptions

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -9,6 +9,7 @@ This repository follows the agent engineering kernel.
 - each non-trivial slice is classified before edits as `repo_local_slice` or `external_contract_slice`
 - repo-owned slices may proceed from project truth, deterministic verification, and local runtime checks
 - slices that change or claim current external-system behavior require fresh external research before code or docs land
+- every `external_contract_slice` records an `external_source_of_truth_matrix` so project pins, vendor docs, exact versions, and live verification are reconciled explicitly
 - GitHub hierarchy:
   - `Epic`
   - `Task`

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -12,6 +12,19 @@ Describe the current gap.
 
 Verified facts only.
 
+## External Source-Of-Truth Matrix
+
+Required for `external_contract_slice`. One entry per external surface in scope.
+
+Canonical field name: `external_source_of_truth_matrix`
+
+- `surface_name`:
+- `project_local_source_of_truth`:
+- `upstream_or_vendor_source`:
+- `exact_version_commit_build_url_or_identifier`:
+- `local_verification_method`:
+- `divergence_notes`:
+
 ## Target State
 
 What should be true after the change.

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -56,8 +56,17 @@ class RepoKernelCanonTests(unittest.TestCase):
             research_policy["slice_classification"]["allowed_values"],
             ["repo_local_slice", "external_contract_slice"],
         )
+        self.assertIn("external_source_of_truth_matrix", research_policy)
+        self.assertEqual(
+            research_policy["external_source_of_truth_matrix"]["required_for"],
+            ["external_contract_slice"],
+        )
         self.assertIn(
             "external_contract_slice_requires_fresh_external_research_before_code_or_docs_land",
+            research_policy["rules"],
+        )
+        self.assertIn(
+            "every_external_contract_slice_must_record_an_external_source_of_truth_matrix_before_implementation_lands",
             research_policy["rules"],
         )
 
@@ -153,6 +162,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("repo_local_slice", content, rel)
             self.assertIn("external_contract_slice", content, rel)
             self.assertIn("fresh external research", content, rel)
+            self.assertIn("external_source_of_truth_matrix", content, rel)
 
     def test_kernel_docs_and_templates_mention_shell_safe_gh_delivery(self) -> None:
         for rel in (
@@ -198,6 +208,19 @@ class RepoKernelCanonTests(unittest.TestCase):
             if rel != "references/KERNEL_UPSTREAM_AWARENESS.md":
                 self.assertIn("kernel_sync_review", content, rel)
                 self.assertIn("Kernel Impact", content, rel)
+
+    def test_kernel_docs_and_templates_mention_external_source_of_truth_matrix(self) -> None:
+        for rel in (
+            "README.md",
+            "references/RESEARCH_POLICY.md",
+            "references/BOOTSTRAP.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("external_source_of_truth_matrix", content, rel)
 
     def test_kernel_docs_mention_kernel_fleet_sweep(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary

- add `external_source_of_truth_matrix` to the kernel research canon for every `external_contract_slice`
- thread the rule through README, research policy, bootstrap guidance, project templates, and the PRD template
- add regression coverage so bootstrapped repos inherit the matrix requirement

## Verification

- `.venv/bin/python -m unittest tests.test_repo_kernel_canon`
- `git diff --check`

Closes #26
