### PR TITLE
Add behavioral overlay sync canon (#28)

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -14,6 +14,7 @@ layers:
     - prd_first_execution
     - research_policy
     - execution_surface_policy
+    - optional_behavioral_overlay_policy
     - kernel_upstream_awareness_policy
     - kernel_adoption_task_policy
     - kernel_sync_policy
@@ -121,6 +122,29 @@ execution_surface_policy:
     - detect_local_prerequisites_before_work_starts
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
     - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
+
+behavioral_overlay_policy:
+  bootstrap_default: false
+  purpose:
+    - allow_an_optional_behavior_only_layer_without_replacing_repo_canon_or_the_engineering_kernel
+    - keep_one_canonical_overlay_source_syncable_across_claude_cursor_skill_and_plugin_surfaces
+  candidate_principles:
+    - explicit_assumptions_and_named_confusion
+    - simplicity_first
+    - surgical_changes
+    - goal_driven_verification
+  allowed_surfaces:
+    - CLAUDE_md_style_root_instruction_file
+    - Cursor_project_rule
+    - skill_or_plugin_surface
+  rules:
+    - behavioral_overlay_is_optional_not_bootstrap_default
+    - behavioral_overlay_must_stay_thin_relative_to_repo_canon_and_the_engineering_kernel
+    - repo_local_canon_remains_higher_priority_than_any_behavioral_overlay
+    - if_multiple_agent_surfaces_are_used_keep_one_canonical_overlay_source_and_sync_the_derived_variants
+    - do_not_let_claude_cursor_skill_or_plugin_variants_drift_semantically
+    - do_not_replace_prd_issue_verification_or_kernel_sync_discipline_with_a_behavior_only_overlay
+    - enable_always_apply_or_auto_apply_only_by_explicit_project_choice_not_as_universal_kernel_default
 
 optional_operator_layers:
   - kernel_fleet_sweep_policy

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Model-specific behavior is a thin adapter only:
 - verbosity
 - planning mechanics
 
+Optional behavioral overlays are also allowed, but they stay thin:
+
+- one compact behavior layer may be reused across `CLAUDE.md`, Cursor rules, and skill/plugin surfaces;
+- that layer must remain subordinate to the engineering kernel and the project-local canon;
+- keep one canonical overlay source and sync the derived surfaces instead of letting them drift;
+- `alwaysApply` or implicit auto-apply is a project-level choice, not a universal kernel default.
+
 Do not fork the engineering process by model unless a tool constraint truly forces it.
 
 ## Repository contents
@@ -98,6 +105,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how to materialize the kernel into a project
 - [references/MODEL_ADAPTERS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/MODEL_ADAPTERS.md)
   - model adapter policy
+- [references/BEHAVIORAL_OVERLAY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/BEHAVIORAL_OVERLAY.md)
+  - thin behavior-layer policy for `CLAUDE.md` / Cursor / skill/plugin surfaces
 - [references/EXECUTION_SURFACES.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/EXECUTION_SURFACES.md)
   - local-first versus GitHub Actions execution policy
 - [references/KERNEL_SYNC_POLICY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/KERNEL_SYNC_POLICY.md)
@@ -130,6 +139,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - decision record for this repository
 - [docs/research-boundary-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/research-boundary-prd-2026-04-18.md)
   - decision record for the research-boundary classification rule
+- [docs/behavioral-overlay-policy-prd-2026-04-20.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/behavioral-overlay-policy-prd-2026-04-20.md)
+  - decision record for optional thin behavior-only overlays across `CLAUDE.md` / Cursor / skill-plugin surfaces
 - [docs/kernel-adoption-task-prd-2026-04-18.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/docs/kernel-adoption-task-prd-2026-04-18.md)
   - decision record for the canonical downstream kernel adoption task
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when the task is to establish or upgrade a repository's engineeri
 Read [ENGINEERING_KERNEL.yaml](ENGINEERING_KERNEL.yaml) for the machine-readable core.
 Read [references/BOOTSTRAP.md](references/BOOTSTRAP.md) when you need to materialize the kernel into a project.
 Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user asks how the kernel should map across GPT/Codex and Claude-style agents.
+Read [references/BEHAVIORAL_OVERLAY.md](references/BEHAVIORAL_OVERLAY.md) when the user asks whether a thin behavior-only guideline layer should exist across `CLAUDE.md`, Cursor rules, or skill/plugin surfaces.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.

--- a/docs/behavioral-overlay-policy-prd-2026-04-20.md
+++ b/docs/behavioral-overlay-policy-prd-2026-04-20.md
@@ -1,0 +1,63 @@
+# PRD: Thin behavioral overlay and multi-surface sync policy
+
+Date: `2026-04-20`
+
+Status: `completed`
+
+Primary Task: `#28`
+
+## Problem
+
+Some projects want a compact behavior-only layer for agent ergonomics across surfaces such as:
+
+- `CLAUDE.md`
+- Cursor rules
+- skill/plugin wrappers
+
+That pattern can be useful, but it creates two recurring failure modes when it is adopted without kernel discipline:
+
+- one small behavior file starts pretending to be the whole engineering operating system;
+- multiple tool-specific copies drift until each surface teaches a different workflow.
+
+The shared kernel needs an explicit rule for when this pattern is acceptable and what boundary keeps it from replacing repo canon.
+
+## Research Basis
+
+- Slice classification: `repo_local_slice`
+- Project-local source reviewed: `forrestchang/andrej-karpathy-skills`
+
+Verified observations from the reviewed repository:
+
+- the strongest reusable idea is structural, not textual;
+- one compact behavior layer is materialized across several agent surfaces;
+- the repository treats those surfaces as synchronized variants of the same small guidance set.
+
+## Decision
+
+The universal kernel now allows an optional behavioral overlay layer with these hard constraints:
+
+- it is optional, not bootstrap default;
+- it stays thin relative to the engineering kernel and the project-local canon;
+- if several agent surfaces exist, there must be one canonical overlay source and the rest are derived variants;
+- `AGENTS.md`, PRD-first execution, issue-first delivery, verification, `kernel_upstream_check`, and `kernel_sync_review` remain higher priority than the overlay;
+- auto-apply or `alwaysApply` behavior is a project-level choice, not a universal kernel default.
+
+## Files To Change
+
+- `ENGINEERING_KERNEL.yaml`
+- `README.md`
+- `SKILL.md`
+- `references/BEHAVIORAL_OVERLAY.md`
+- `references/BOOTSTRAP.md`
+- `references/MODEL_ADAPTERS.md`
+- `templates/project/AGENTS.md`
+- `templates/project/README.md`
+- `tests/test_repo_kernel_canon.py`
+
+## Success Condition
+
+The kernel is correct for this slice when:
+
+- future projects can adopt a thin behavior-only layer without confusing it for the full workflow canon;
+- multi-surface overlays are treated as one synced concept rather than drifting independent files;
+- the shared kernel remains model-agnostic and process-first.

--- a/references/BEHAVIORAL_OVERLAY.md
+++ b/references/BEHAVIORAL_OVERLAY.md
@@ -1,0 +1,76 @@
+# Behavioral Overlay Policy
+
+Use this reference when a project wants a thin behavior-only layer for agents in addition to the engineering kernel.
+
+## Purpose
+
+The engineering kernel is the operating system.
+
+A behavioral overlay is only a small reinforcement layer for model behavior. It can help with:
+
+- explicit assumptions instead of silent guessing
+- simplicity over overengineering
+- surgical edits instead of drive-by rewrites
+- goal-driven verification instead of vague "make it work"
+
+This is useful, but it must not replace the kernel.
+
+## Hard boundary
+
+Behavioral overlays are:
+
+- optional
+- thin
+- subordinate to project canon
+
+They must not replace:
+
+- PRD-first execution
+- GitHub `Epic / Task / Bug`
+- verification discipline
+- `kernel_upstream_check`
+- `kernel_sync_review`
+- research classification
+
+## Multi-surface sync rule
+
+If a project uses several agent surfaces, keep one canonical behavioral-overlay source and derive the rest from it.
+
+Typical derived surfaces:
+
+- `CLAUDE.md`-style root instructions
+- Cursor project rules
+- skill/plugin variants
+
+Do not let these drift semantically. Different syntax is acceptable; different meaning is not.
+
+## What to borrow from compact guideline repos
+
+The reusable pattern is structural, not textual:
+
+- one compact behavioral layer
+- repeated consistently across several agent surfaces
+- intentionally merged with stronger project-local rules
+
+What not to borrow blindly:
+
+- replacing the repo canon with a single-file guideline
+- enabling `alwaysApply` / implicit auto-apply as a universal default
+- copying another repo's exact phrasing without reconciling it with the local kernel and project canon
+
+## Recommended universal candidate principles
+
+These principles are reasonable overlay candidates across many projects:
+
+1. State assumptions explicitly. If confused, name it.
+2. Prefer the simplest code that solves the asked problem.
+3. Touch only what is necessary; clean up only what your slice made obsolete.
+4. Define success through verification, not only through intent.
+
+## Project adoption rule
+
+If a consumer repository adopts a behavioral overlay:
+
+- document that it is optional and thin;
+- document that `AGENTS.md`, PRD, tests, and repo-local canon outrank it;
+- if several tool-specific variants exist, record which file is canonical and which files are derived.

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -43,6 +43,7 @@ The bootstrapped canon should also make explicit:
 - that active PRDs and closeouts carry a `Kernel Impact` decision
 - that the consumer project pins the exact kernel commit it bootstrapped from
 - that every `external_contract_slice` records an explicit `external_source_of_truth_matrix` in the active PRD or decision note
+- that any optional `CLAUDE.md` / Cursor rule / skill-style behavior overlay is thin, subordinate to repo canon, and synced from one canonical overlay source if the project chooses to use it
 
 ## How to use the templates
 
@@ -60,6 +61,8 @@ python3 scripts/sync_github_labels.py --apply
 ```
 
 Do not blindly overwrite stronger project-local canon unless the task is an intentional migration.
+
+Do not treat a compact behavior guideline file as a replacement for the bootstrapped canon. If a project wants that extra layer, add it separately and keep it thin.
 
 Bootstrap should pin the current kernel commit into `.kernel/upstream.json` instead of leaving placeholder or branch-only metadata.
 

--- a/references/MODEL_ADAPTERS.md
+++ b/references/MODEL_ADAPTERS.md
@@ -18,6 +18,23 @@ The engineering kernel is shared. The model adapter is thin.
 - shell/editor constraints
 - verbosity and final report style
 - local skills/plugins/integrations
+- whether a thin behavior-only overlay is materialized in a tool-specific surface
+
+## Behavioral overlay rule
+
+An optional behavior-only layer may exist across tool-specific surfaces such as:
+
+- `CLAUDE.md`
+- Cursor project rules
+- skill/plugin wrappers
+
+But it must stay:
+
+- thin
+- synced from one canonical source
+- lower priority than the repo-local canon and the shared engineering kernel
+
+Do not confuse a behavior overlay with the engineering workflow itself.
 
 ## Hard rule
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -93,6 +93,14 @@ This repository follows the agent engineering kernel.
 - live checks when runtime or state changes
 - rollback path
 
+## Optional behavioral overlays
+
+If this repository also uses a thin behavior-only layer such as `CLAUDE.md`, a Cursor project rule, or a skill/plugin wrapper:
+
+- keep it optional and thin;
+- keep one canonical overlay source if several derived variants exist;
+- treat this `AGENTS.md`, the PRD, tests, and repo-local canon as higher priority than that overlay.
+
 ## Canon files
 
 - `README.md`

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -33,6 +33,7 @@ This repository follows the agent engineering kernel.
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
 - for GitHub sub-issues, prefer `scripts/link_github_sub_issue.py`; if you call REST directly, `sub_issue_id` means child issue database id, not `#issue_number`
 - GitHub Projects are optional and should be adopted only when issue-first execution needs shared fields/views or cross-repo planning
+- any optional `CLAUDE.md` / Cursor / skill-style behavior overlay must stay thin and subordinate to the repo-local canon
 
 ## Canon files
 

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -23,6 +23,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "scripts/sync_github_labels.py",
             "scripts/link_github_sub_issue.py",
             "references/BOOTSTRAP.md",
+            "references/BEHAVIORAL_OVERLAY.md",
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
             "references/KERNEL_FLEET_SWEEP.md",
@@ -46,6 +47,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("automatic_bug_intake", payload)
         self.assertIn("execution_surface_policy", payload)
         self.assertIn("optional_operator_layers", payload)
+        self.assertIn("behavioral_overlay_policy", payload)
         self.assertIn("kernel_upstream_awareness_policy", payload)
         self.assertIn("kernel_adoption_task_policy", payload)
         self.assertIn("kernel_fleet_sweep_policy", payload)
@@ -231,6 +233,21 @@ class RepoKernelCanonTests(unittest.TestCase):
         ):
             content = (ROOT / rel).read_text(encoding="utf-8")
             self.assertIn("kernel_fleet_sweep", content, rel)
+
+    def test_kernel_docs_and_templates_mention_behavioral_overlay_policy(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/BEHAVIORAL_OVERLAY.md",
+            "references/MODEL_ADAPTERS.md",
+            "references/BOOTSTRAP.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("thin", content.lower(), rel)
+            self.assertIn("Cursor", content, rel)
+            self.assertIn("CLAUDE.md", content, rel)
 
     def test_kernel_docs_and_templates_mention_kernel_adoption_task(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary
- add a universal thin behavioral overlay policy to the shared engineering kernel
- document the multi-surface sync rule for CLAUDE.md, Cursor, and skill/plugin surfaces
- add regression coverage so overlays stay optional and subordinate to repo canon

## Verification
- .venv/bin/python -m unittest discover -s tests
- git diff --check
