### PR TITLE
[codex] Add pre-change baseline verification rule

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -55,11 +55,16 @@ prd_first_execution:
     - code_audit
     - reconciliation
     - documentation_first
+    - baseline_verification
     - implementation
-    - verification
+    - post_change_verification
   rules:
     - non_trivial_work_must_not_start_with_code
     - verification_defined_before_edits
+    - capture_smallest_relevant_baseline_verification_before_edits_when_existing_contract_exists
+    - bugfix_slices_prefer_reproducer_before_fix
+    - refactor_slices_prefer_before_and_after_equivalence_checks
+    - docs_only_canon_only_or_greenfield_slices_may_skip_pre_change_baseline_if_no_existing_contract_exists
     - docs_and_prd_are_part_of_the_slice
 
 research_policy:
@@ -266,9 +271,10 @@ github_delivery_flow:
     - open_parent_issue_if_needed
     - create_leaf_issue
     - create_branch_from_leaf_issue
+    - capture_baseline_verification_when_relevant
     - implement_in_small_slice
     - open_or_update_draft_pr
-    - run_verification
+    - run_post_change_verification
     - mark_pr_ready
     - squash_merge
     - delete_head_branch
@@ -292,9 +298,11 @@ pr_verification_contract:
     - linked_leaf_issue
     - parent_context
     - scope
+    - baseline_verification
     - verification
     - rollback_path
   minimum_checks:
+    - pre_change_baseline_when_existing_contract_exists
     - code_path_tests
     - build_or_runtime_checks
     - source_of_truth_or_sync_checks

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Shared core:
 - code audit
 - reconciliation
 - documentation first
+- baseline verification when an existing contract already exists
 - implementation
-- verification
+- post-change verification
 - GitHub `Epic / Task / Bug` hierarchy
 - automatic deduplicated `Bug` intake from verifier/watchdog/runtime gates
 - PR closes leaf issue only
@@ -58,6 +59,15 @@ Research canon:
 - every `external_contract_slice` records an `external_source_of_truth_matrix` in the active PRD or decision note
 - official docs for external contracts
 - known URLs fetched directly when already available
+
+Verification canon:
+
+- define verification before edits
+- when a deterministic contract already exists, capture the smallest relevant baseline before editing
+- for bugfixes, prefer a reproducer first
+- for refactors, prefer before/after equivalence checks
+- for docs-only, canon-only, or greenfield slices without an existing contract, do not invent a fake pre-change baseline
+- post-change verification before publish remains mandatory
 
 Kernel sync canon:
 

--- a/docs/pre-change-baseline-verification-kernel-prd-2026-04-20.md
+++ b/docs/pre-change-baseline-verification-kernel-prd-2026-04-20.md
@@ -1,0 +1,52 @@
+## Pre-Change Baseline Verification Kernel Rule
+
+Date: 2026-04-20
+Issue: #30
+Status: `implemented`
+Classification: `project_local_only`
+Kernel Impact: `n/a`
+
+## Problem
+
+The kernel already required verification before merge, but it did not yet state one earlier reusable rule strongly enough: when a deterministic contract already exists, capture the smallest relevant baseline verification before edits begin.
+
+Without that rule, agents can still:
+
+- refactor against an unverified mental model;
+- “fix” bugs without reproducing the real failure mode first;
+- change existing behavior without proving what the old contract was.
+
+## Decision
+
+Add a universal verification rule to the kernel:
+
+- if a deterministic contract already exists, capture the smallest relevant baseline verification before edits;
+- for bugfixes, prefer a reproducer first;
+- for refactors, prefer before/after equivalence checks;
+- for features that change existing behavior, run the focused current-contract baseline before edits when practical, then rerun verification after the change;
+- for docs-only, canon-only, or greenfield slices with no existing contract, define verification before edits but do not invent a fake baseline.
+
+This is not universal “always TDD” dogma. It is a narrower goal-driven verification rule that fits serious engineering work across repositories.
+
+## Scope
+
+Update the reusable kernel only:
+
+- [ENGINEERING_KERNEL.yaml](/Users/raketa23/Work/Vs/agent-engineering-kernel/ENGINEERING_KERNEL.yaml)
+- [README.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/README.md)
+- [references/GITHUB_DELIVERY.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/references/GITHUB_DELIVERY.md)
+- [templates/project/AGENTS.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/templates/project/AGENTS.md)
+- [templates/project/CONTRIBUTING.md](/Users/raketa23/Work/Vs/agent-engineering-kernel/templates/project/CONTRIBUTING.md)
+- kernel tests
+
+## Acceptance
+
+- machine-readable kernel includes pre-change baseline verification when relevant;
+- kernel README and delivery reference explain the difference between baseline-before-edits and post-change verification;
+- project templates inherit the rule;
+- kernel tests protect the new rule.
+
+## Verification
+
+- `.venv/bin/python -m unittest discover -s tests`
+- `git diff --check`

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -14,17 +14,19 @@ Execution-surface rule:
 2. Open the parent `Epic` if the work is non-trivial
 3. Create the executable leaf issue (`Task` or `Bug`)
 4. Create the branch from the leaf issue
-5. Implement in a small slice
-6. Open or update a draft PR
-7. Run verification
-8. Mark the PR ready
-9. Merge
-10. Delete the head branch
+5. Capture baseline verification when an existing deterministic contract already exists
+6. Implement in a small slice
+7. Open or update a draft PR
+8. Run post-change verification
+9. Mark the PR ready
+10. Merge
+11. Delete the head branch
 
 ## Rules
 
 - PR closes the leaf issue only
 - parent epic stays open until all required leaf issues and acceptance checks are complete
+- baseline-before-edits and post-change verification are different moments; keep both explicit when an existing contract already exists
 - keep the PR description aligned with the real scope and verification
 - use draft PR while the scope or verification is still moving
 - prefer squash merge unless the project canon explicitly chooses another method

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -8,8 +8,9 @@ This repository follows the agent engineering kernel.
 2. Code audit
 3. Reconciliation
 4. Documentation first
-5. Implementation
-6. Verification
+5. Baseline verification when an existing deterministic contract already exists
+6. Implementation
+7. Post-change verification
 
 ## Research canon
 
@@ -78,20 +79,28 @@ This repository follows the agent engineering kernel.
 2. open parent issue if needed
 3. create executable leaf issue
 4. create branch from the leaf issue
-5. implement in a small slice
-6. open or update draft PR
-7. run verification
-8. mark PR ready
-9. merge
-10. delete head branch
+5. capture baseline verification when an existing deterministic contract already exists
+6. implement in a small slice
+7. open or update draft PR
+8. run post-change verification
+9. mark PR ready
+10. merge
+11. delete head branch
 
 ## Minimum verification contract
 
+- pre-change baseline when an existing deterministic contract already exists
 - code-path tests
 - build/runtime checks
 - source-of-truth / sync checks
 - live checks when runtime or state changes
 - rollback path
+
+Rules:
+
+- bugfixes should prefer a reproducer before the fix;
+- refactors should prefer before/after equivalence checks;
+- docs-only, canon-only, or greenfield slices may skip pre-change baseline only when no existing deterministic contract exists.
 
 ## Optional behavioral overlays
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -81,8 +81,18 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 - linked leaf issue
 - parent context
 - write scope
+- baseline verification
 - verification
 - rollback path
+
+## Verification timing
+
+- define verification before edits
+- when an existing deterministic contract already exists, capture the smallest relevant baseline before implementation begins
+- bugfixes should prefer a reproducer before the fix
+- refactors should prefer before/after equivalence checks
+- docs-only, canon-only, or greenfield slices may skip pre-change baseline only when no existing deterministic contract exists
+- post-change verification before merge remains mandatory
 
 ## Repo-managed metadata
 

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -52,6 +52,13 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("kernel_adoption_task_policy", payload)
         self.assertIn("kernel_fleet_sweep_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
+        prd_first = payload["prd_first_execution"]
+        self.assertIn("baseline_verification", prd_first["order"])
+        self.assertIn("post_change_verification", prd_first["order"])
+        self.assertIn(
+            "capture_smallest_relevant_baseline_verification_before_edits_when_existing_contract_exists",
+            prd_first["rules"],
+        )
         research_policy = payload["research_policy"]
         self.assertIn("slice_classification", research_policy)
         self.assertEqual(
@@ -71,6 +78,25 @@ class RepoKernelCanonTests(unittest.TestCase):
             "every_external_contract_slice_must_record_an_external_source_of_truth_matrix_before_implementation_lands",
             research_policy["rules"],
         )
+
+    def test_kernel_readme_and_templates_document_pre_change_baseline_rule(self) -> None:
+        readme_text = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("baseline verification when an existing contract already exists", readme_text)
+        self.assertIn("post-change verification", readme_text)
+
+        agents_text = (ROOT / "templates" / "project" / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("capture baseline verification when an existing deterministic contract already exists", agents_text)
+        self.assertIn("## Minimum verification contract", agents_text)
+        self.assertIn("bugfixes should prefer a reproducer before the fix", agents_text)
+
+        contributing_text = (ROOT / "templates" / "project" / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        self.assertIn("baseline verification", contributing_text)
+        self.assertIn("Verification timing", contributing_text)
+        self.assertIn("refactors should prefer before/after equivalence checks", contributing_text)
+
+        delivery_text = (ROOT / "references" / "GITHUB_DELIVERY.md").read_text(encoding="utf-8")
+        self.assertIn("Capture baseline verification when an existing deterministic contract already exists", delivery_text)
+        self.assertIn("baseline-before-edits and post-change verification are different moments", delivery_text)
 
     def test_project_templates_include_minimal_core(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary
- add a reusable kernel rule for baseline verification before edits when an existing deterministic contract already exists
- update the machine-readable kernel, kernel README, delivery reference, project templates, and kernel tests
- record the kernel-side decision in a dedicated PRD

## Why
The kernel already enforced verification before merge, but it did not yet encode the earlier reusable rule strongly enough. The useful adoption from the Karpathy-style pattern is not universal always-TDD; it is pre-change baseline plus post-change verification.

## Verification
- `.venv/bin/python -m unittest discover -s tests`
- `git diff --check`

Closes #30
