### PR TITLE
Add live external sandbox identity guardrail

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -307,6 +307,12 @@ pr_verification_contract:
     - build_or_runtime_checks
     - source_of_truth_or_sync_checks
     - live_checks_when_runtime_or_state_is_touched
+    - sandbox_identity_for_live_external_writes
+  live_external_identity_rules:
+    - if_live_verification_can_write_to_external_state_use_explicit_sandbox_identity
+    - never_use_operator_or_production_identities_as_test_identities
+    - if_more_identities_are_needed_provision_and_record_more_sandboxes_before_testing
+    - fail_closed_when_required_sandbox_identity_or_resource_ids_are_not_configured
 
 ownership_and_metadata:
   required_files:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Verification canon:
 - for bugfixes, prefer a reproducer first
 - for refactors, prefer before/after equivalence checks
 - for docs-only, canon-only, or greenfield slices without an existing contract, do not invent a fake pre-change baseline
+- live verification that can write to an external service must use explicitly designated sandbox identities, never operator or production identities
 - post-change verification before publish remains mandatory
 
 Kernel sync canon:

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -94,6 +94,7 @@ This repository follows the agent engineering kernel.
 - build/runtime checks
 - source-of-truth / sync checks
 - live checks when runtime or state changes
+- sandbox identity guardrails for live external writes
 - rollback path
 
 Rules:
@@ -101,6 +102,7 @@ Rules:
 - bugfixes should prefer a reproducer before the fix;
 - refactors should prefer before/after equivalence checks;
 - docs-only, canon-only, or greenfield slices may skip pre-change baseline only when no existing deterministic contract exists.
+- live verification that can write to an external service must use explicitly designated sandbox identities, never operator or production identities.
 
 ## Optional behavioral overlays
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -83,6 +83,7 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 - write scope
 - baseline verification
 - verification
+- sandbox identity confirmation for live external writes
 - rollback path
 
 ## Verification timing
@@ -93,6 +94,7 @@ If the work spans multiple slices, decompose it into GitHub sub-issues.
 - refactors should prefer before/after equivalence checks
 - docs-only, canon-only, or greenfield slices may skip pre-change baseline only when no existing deterministic contract exists
 - post-change verification before merge remains mandatory
+- live verification that can write to an external service must use explicitly designated sandbox identities, never operator or production identities
 
 ## Repo-managed metadata
 


### PR DESCRIPTION
Closes #34.\n\n## Summary\n- adds the universal rule that live external writes must use designated sandbox identities\n- records the rule in the machine-readable kernel and project templates\n\n## Verification\n- git diff --check\n