### PR TITLE
Strengthen owned-compute execution canon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,28 +17,28 @@ permissions:
 jobs:
   test:
     name: unittest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, agent-kernel-ci]
     timeout-minutes: 5
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python: ["python3.11", "python3.12"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
+      - name: Check Python
+        run: ${{ matrix.python }} --version
 
       - name: Install dev dependencies
         run: |
+          ${{ matrix.python }} -m venv .venv-${{ matrix.python }}
+          . .venv-${{ matrix.python }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
       - name: Run unittests
-        run: python -m unittest discover -s tests -v
+        run: |
+          . .venv-${{ matrix.python }}/bin/activate
+          python -m unittest discover -s tests -v

--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -119,6 +119,7 @@ execution_surface_policy:
   default_surface:
     - local_operator_machine
     - self_hosted_runner_when_project_already_has_one
+    - self_hosted_runner_when_project_can_reasonably_provide_one
   github_actions_are_for:
     - repository_native_automation
     - scheduled_workflows
@@ -126,7 +127,10 @@ execution_surface_policy:
     - hosted_verification_that_requires_repository_runtime
     - event_driven_jobs_that_should_run_without_an_operator_terminal
   rules:
+    - github_coordinates_repository_workflow_owned_compute_executes_routine_work_by_default
     - do_not_default_to_paid_github_hosted_actions_for_ordinary_development_work
+    - paid_github_hosted_runners_dependency_cache_uploads_and_long_lived_artifacts_require_explicit_prd_or_decision_note
+    - document_self_hosted_runner_labels_before_enabling_recurring_github_checks
     - if_work_can_run_locally_prefer_local_execution_first
     - detect_local_prerequisites_before_work_starts
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ The goal is simple: a new agent in a new repository should not need the workflow
 Execution-surface canon:
 
 - ordinary engineering work should default to the local operator machine first
-- self-hosted runners are preferred over paid GitHub-hosted Actions when the repository already has them
+- GitHub coordinates repository workflow: issues, PRs, check status, schedules, and deploy triggers
+- owned compute executes routine work by default: local machine first, then self-hosted runners for recurring checks
+- self-hosted runners are preferred over paid GitHub-hosted Actions when the repository already has them or can reasonably provide them
+- paid GitHub-hosted runners, dependency cache uploads, and long-lived artifact storage are explicit exceptions for private repositories, not defaults
 - GitHub Actions remain for repo-native automation, schedules, deploys, and hosted checks that actually belong there
 
 ## Core idea

--- a/docs/owned-compute-execution-surface-prd-2026-04-24.md
+++ b/docs/owned-compute-execution-surface-prd-2026-04-24.md
@@ -1,0 +1,72 @@
+# Owned-Compute Execution Surface PRD
+
+Date: 2026-04-24
+Issue: `#36`
+Slice classification: `external_contract_slice`
+
+## Problem
+
+The kernel already said local/self-hosted execution should come before paid
+GitHub-hosted Actions. A downstream repository produced a stronger live lesson:
+private-repo GitHub-hosted runners and Actions cache/storage are not just a
+minor convenience; they can become a billing blocker and can consume money even
+when the engineering work itself is routine.
+
+The universal rule should be explicit enough that future project bootstraps do
+not accidentally treat GitHub-hosted compute as the default executor.
+
+## External Source Baseline
+
+GitHub docs checked on 2026-04-24:
+
+- GitHub Actions usage is free for self-hosted runners.
+- Private repositories consume included/billed runner minutes and
+  artifact/cache storage when using GitHub-hosted runners.
+- `jobs.<job_id>.runs-on` selects runner labels for workflow jobs.
+
+Sources:
+
+- https://docs.github.com/en/billing/concepts/product-billing/github-actions
+- https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job
+- https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/add-runners
+
+## Decision
+
+Promote this wording into the universal kernel:
+
+- GitHub coordinates repository workflow: issues, PRs, check status, schedules,
+  and deploy triggers.
+- Owned compute executes routine work by default: local operator machine first,
+  then self-hosted runners for recurring repository checks.
+- Paid GitHub-hosted runners are explicit exceptions, not defaults.
+- GitHub dependency cache uploads and long-lived artifacts are also paid-surface
+  decisions in private repositories, so they require explicit acceptance.
+- Project canon must document self-hosted runner labels before enabling
+  recurring GitHub checks.
+
+## Acceptance
+
+- References describe GitHub as coordinator/orchestrator and owned compute as
+  default executor.
+- Project templates carry the stronger rule.
+- The machine-readable kernel carries the stronger rule.
+- Kernel's own test workflow stops using `ubuntu-latest` and GitHub dependency
+  cache by default.
+- Tests guard the wording.
+
+## Verification
+
+Completed:
+
+- `python3.11` venv: `python -m unittest discover -s tests -v` -> 33 passed.
+- `python3.12` venv: `python -m unittest discover -s tests -v` -> 33 passed.
+- `python3.12` venv: `python -m unittest tests.test_repo_kernel_canon -v`.
+- `git diff --check`.
+
+Note: do not use bare `python3` as the kernel verification contract on this
+operator machine; it currently points at `Python 3.14`, while the kernel workflow
+intentionally verifies with runner-owned `python3.11` and `python3.12`.
+
+## Kernel Impact
+
+`promote_to_kernel`

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -36,8 +36,10 @@ The bootstrapped canon should also make explicit:
 - canonical local bootstrap command
 - canonical local verifier/test commands
 - whether the repo uses self-hosted runners
+- the self-hosted runner label(s) if recurring GitHub checks are required
 - which workflows must stay in GitHub Actions
-- that routine development and verification should not default to paid GitHub-hosted Actions
+- that GitHub coordinates repository workflow but owned compute executes routine development and verification by default
+- that routine development and verification should not default to paid GitHub-hosted Actions, dependency cache uploads, or long-lived artifact storage
 - that each serious slice begins with `kernel_upstream_check`
 - that each serious slice ends with `kernel_sync_review`
 - that active PRDs and closeouts carry a `Kernel Impact` decision

--- a/references/EXECUTION_SURFACES.md
+++ b/references/EXECUTION_SURFACES.md
@@ -10,7 +10,13 @@ Default to the cheapest correct execution surface.
 For ordinary engineering work, that usually means:
 
 - the local operator machine first
-- a self-hosted runner next, if the repository already has one
+- a self-hosted runner next, if the repository already has one or can
+  reasonably provide one
+
+GitHub coordinates repository workflow: issues, pull requests, check status,
+scheduled triggers, and deployment triggers. It is not the default compute
+surface for routine development, verification, research, bootstrap, or audit
+work. Owned compute executes routine work by default.
 
 Do **not** default to paid GitHub-hosted Actions for work that can be executed
 locally.
@@ -47,11 +53,17 @@ Use GitHub Actions when the value is specifically repository-native automation:
 
 For private repositories, GitHub-hosted Actions consume billed/included runner
 minutes. Self-hosted runners do not consume those GitHub-hosted minutes.
+Actions artifacts and dependency caches can also consume billed/included
+storage. Large dependency cache uploads are paid-surface work too, not a
+harmless default.
 
 So the kernel rule is:
 
 - local/self-hosted first for ordinary work
-- GitHub Actions for automation that genuinely belongs there
+- GitHub as the delivery/check coordinator
+- owned compute as the default executor
+- GitHub-hosted runners or cache/artifact storage only when a PRD/decision note
+  explicitly accepts that paid surface
 
 ## What to encode in project canon
 
@@ -60,6 +72,9 @@ Project-local canon should state:
 - the canonical local bootstrap command
 - the canonical local test/verifier commands
 - whether the project has self-hosted runners
+- the self-hosted runner label(s) for recurring repository checks
 - which workflows must remain in GitHub Actions
 - that agents should not route routine dev/test work to paid hosted Actions by
   default
+- that dependency cache uploads and artifact retention are disabled or bounded
+  unless the project explicitly accepts GitHub storage usage

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -5,8 +5,10 @@ Use this when the user wants the full branch / PR / merge discipline, not just i
 Execution-surface rule:
 
 - GitHub delivery flow does not mean GitHub-hosted Actions are the default place to do ordinary engineering work
+- GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute executes routine work by default
 - local operator execution or self-hosted runners stay primary for normal dev/test/bootstrap work
 - GitHub Actions are for repository-native automation, scheduled/event jobs, deploys, and hosted verification that must live in the platform
+- paid GitHub-hosted runners, dependency caches, and long-lived artifacts in private repositories require an explicit PRD/decision note that accepts the paid surface
 
 ## Canonical sequence
 

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -29,10 +29,13 @@ This repository follows the agent engineering kernel.
 ## Execution surface canon
 
 - prefer the local operator machine first for ordinary development, debugging, research, and verification
-- if the project already has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute should execute routine work by default
+- if the project already has self-hosted runners or can reasonably provide them, prefer them over paid GitHub-hosted Actions for recurring work
+- document the project self-hosted runner label(s) before enabling recurring GitHub checks
 - check local prerequisites before work starts
 - if the repo defines a local bootstrap path, use or repair it before escalating elsewhere
 - use GitHub Actions for repository-native automation, schedules, deploys, and hosted verification that genuinely belongs there
+- do not enable paid GitHub-hosted runners, dependency cache uploads, or long-lived artifact storage without an explicit PRD/decision note
 
 ## Kernel sync canon
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -18,9 +18,12 @@ This repository uses a PRD-first and issue-first engineering workflow.
 ## Execution surface policy
 
 - use the local machine first for ordinary development, debugging, research, and verification
-- if the repository already has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute should execute routine work by default
+- if the repository already has self-hosted runners or can reasonably provide them, prefer them over paid GitHub-hosted Actions for recurring work
+- document the self-hosted runner label(s) before enabling recurring GitHub checks
 - check or bootstrap local prerequisites before assuming CI is the right place to run the work
 - keep GitHub Actions for repository-native automation, schedules, deploys, and hosted checks that genuinely need the platform
+- do not enable paid GitHub-hosted runners, dependency cache uploads, or long-lived artifact storage without an explicit PRD/decision note
 
 ## Start from the correct issue
 

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -17,8 +17,11 @@ This repository follows the agent engineering kernel.
   - `Bug`
 - runtime bugs come from verifier/watchdog/runtime-gate fingerprints, not raw logs or chat alerts
 - ordinary development, debugging, and verification should run locally first
-- if the project has self-hosted runners, prefer them over paid GitHub-hosted Actions for recurring work
+- GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute should execute routine work by default
+- if the project has self-hosted runners or can reasonably provide them, prefer them over paid GitHub-hosted Actions for recurring work
+- document self-hosted runner labels before enabling recurring GitHub checks
 - GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
+- paid GitHub-hosted runners, dependency cache uploads, and long-lived artifact storage require an explicit PRD/decision note
 - serious slices begin with `kernel_upstream_check`
 - the project pins its upstream kernel commit in `.kernel/upstream.json`
 - if drift exists, open or update a `kernel_adoption_task`

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -186,6 +186,30 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("local", content.lower(), rel)
             self.assertIn("GitHub Actions", content, rel)
 
+    def test_kernel_docs_and_templates_treat_github_as_coordinator_not_default_compute(self) -> None:
+        for rel in (
+            "README.md",
+            "references/EXECUTION_SURFACES.md",
+            "references/BOOTSTRAP.md",
+            "references/GITHUB_DELIVERY.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("GitHub coordinates", content, rel)
+            self.assertIn("owned compute", content, rel)
+            self.assertIn("paid GitHub-hosted", content, rel)
+            self.assertIn("dependency cache", content, rel)
+
+    def test_kernel_workflow_uses_owned_compute_runner(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+        self.assertIn("runs-on: [self-hosted, agent-kernel-ci]", workflow)
+        self.assertIn('python: ["python3.11", "python3.12"]', workflow)
+        self.assertNotIn("ubuntu-latest", workflow)
+        self.assertNotIn("actions/setup-python", workflow)
+        self.assertNotIn("cache: pip", workflow)
+
     def test_kernel_docs_and_templates_mention_research_boundary(self) -> None:
         for rel in (
             "README.md",


### PR DESCRIPTION
## Summary
- promote the owned-compute rule into kernel docs, references, templates, and machine-readable canon
- make GitHub the coordinator and self-hosted/owned compute the default executor
- move the kernel test workflow to self-hosted runner label `agent-kernel-ci`
- add tests guarding the new execution-surface canon

## Verification
- python3.11 venv: `python -m unittest discover -s tests -v` -> 33 passed
- python3.12 venv: `python -m unittest discover -s tests -v` -> 33 passed
- python3.12 venv: `python -m unittest tests.test_repo_kernel_canon -v` -> 18 passed
- `git diff --check`

Closes #36
