### PR TITLE
[codex] Add Superpowers and MCP connector policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added Superpowers-compatible process-skill orchestration to the kernel canon and project templates.
 - Research policy is now explicitly Tavily Search-first, not Tavily Research-first. Tavily Research is reserved for explicitly justified expensive broad deep-sweeps after search, known official docs, and manual synthesis are insufficient.
 
 ## [0.1.0] - 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added Superpowers-compatible process-skill orchestration to the kernel canon and project templates.
+- Added MCP/App connector tooling policy, including GitHub App permission checks, different identities for connector versus local `gh`, and shell-safe fallback behavior.
 - Research policy is now explicitly Tavily Search-first, not Tavily Research-first. Tavily Research is reserved for explicitly justified expensive broad deep-sweeps after search, known official docs, and manual synthesis are insufficient.
 
 ## [0.1.0] - 2026-04-20

--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -12,6 +12,7 @@ layers:
   minimal_core:
     - project_local_canon
     - prd_first_execution
+    - agent_skill_orchestration_policy
     - research_policy
     - execution_surface_policy
     - optional_behavioral_overlay_policy
@@ -66,6 +67,55 @@ prd_first_execution:
     - refactor_slices_prefer_before_and_after_equivalence_checks
     - docs_only_canon_only_or_greenfield_slices_may_skip_pre_change_baseline_if_no_existing_contract_exists
     - docs_and_prd_are_part_of_the_slice
+
+agent_skill_orchestration_policy:
+  preferred_skill_pack: Superpowers
+  role:
+    - tactical_agent_process_layer
+    - not_the_source_of_truth_for_project_requirements_or_repo_canon
+  priority_order:
+    - direct_user_instruction
+    - project_local_canon_and_active_prd
+    - engineering_kernel
+    - applicable_superpowers_or_equivalent_process_skill
+    - model_default_behavior
+  canonical_skill_triggers:
+    project_or_feature_design:
+      - using-superpowers
+      - brainstorming
+    approved_spec_or_multi_step_requirements:
+      - writing-plans
+    implementation_or_bugfix:
+      - test-driven-development
+    bug_failure_or_unexpected_behavior:
+      - systematic-debugging
+    isolated_branch_work:
+      - using-git-worktrees
+    independent_parallel_work:
+      - dispatching-parallel-agents
+    plan_execution_with_subagents:
+      - subagent-driven-development
+    plan_execution_without_subagents:
+      - executing-plans
+    code_review_request_or_response:
+      - requesting-code-review
+      - receiving-code-review
+    completion_claim_or_pr_ready:
+      - verification-before-completion
+      - finishing-a-development-branch
+    skill_authoring:
+      - writing-skills
+  rules:
+    - when_a_relevant_superpowers_skill_or_equivalent_process_skill_is_available_the_agent_must_read_or_invoke_it_before_acting
+    - superpowers_skills_shape_how_the_agent_works_but_do_not_replace_prd_first_issue_first_or_verification_contracts
+    - project_local_canon_active_prd_and_explicit_user_instructions_override_skill_defaults
+    - prefer_skill_backed_brainstorming_for_new_behavior_before_writing_code
+    - prefer_skill_backed_planning_for_multi_step_work_before_touching_code
+    - bugfixes_use_systematic_debugging_before_fixes_and_tdd_for_regression_protection
+    - completion_claims_require_fresh_verification_evidence
+    - subagent_or_parallel_skill_work_requires_platform_support_and_user_or_project_permission
+    - if_skill_tooling_is_unavailable_apply_the_same_principles_manually_and_record_the_gap_when_it_affects_the_slice
+    - do_not_copy_vendor_skill_text_into_project_canon_when_a_small_mapping_or_reference_is_sufficient
 
 research_policy:
   preferred_stack:
@@ -352,6 +402,7 @@ community_health:
 model_adapter_policy:
   shared_core_must_match:
     - prd_first_execution
+    - agent_skill_orchestration_policy
     - github_issue_tree
     - verification_contract
     - documentation_discipline

--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -13,6 +13,7 @@ layers:
     - project_local_canon
     - prd_first_execution
     - agent_skill_orchestration_policy
+    - mcp_tooling_policy
     - research_policy
     - execution_surface_policy
     - optional_behavioral_overlay_policy
@@ -116,6 +117,33 @@ agent_skill_orchestration_policy:
     - subagent_or_parallel_skill_work_requires_platform_support_and_user_or_project_permission
     - if_skill_tooling_is_unavailable_apply_the_same_principles_manually_and_record_the_gap_when_it_affects_the_slice
     - do_not_copy_vendor_skill_text_into_project_canon_when_a_small_mapping_or_reference_is_sufficient
+
+mcp_tooling_policy:
+  preferred_interface: MCP_or_App_connector_when_available
+  role:
+    - structured_external_service_interface
+    - not_a_place_to_store_or_copy_tokens
+    - subordinate_to_project_canon_active_prd_and_verification_contracts
+  identity_boundaries:
+    - github_app_installation_token
+    - local_gh_cli_token
+    - personal_access_token
+    - service_account_or_sandbox_identity
+  github_connector_minimum_permissions:
+    - repository_access_to_target_repo
+    - contents_read_write_when_code_branches_or_files_are_changed
+    - issues_read_write_when_issues_are_created_or_updated
+    - pull_requests_read_write_when_prs_are_created_or_updated
+    - actions_or_workflows_read_write_only_when_workflow_files_or_action_state_are_in_scope
+  rules:
+    - prefer_mcp_or_app_connector_for_supported_structured_external_service_operations
+    - local_cli_tokens_and_mcp_connector_tokens_are_different_identities
+    - github_app_installation_permissions_are_configured_in_github_installed_apps_not_in_the_local_gh_token
+    - do_not_paste_or_record_tokens_in_repo_docs_prds_or_issue_bodies
+    - if_connector_write_fails_check_repository_access_and_app_permissions_before_refreshing_local_cli_auth
+    - when_connector_tooling_is_missing_or_blocked_use_the_canonical_cli_fallback_and_record_the_gap_when_it_affects_the_slice
+    - github_cli_fallbacks_must_follow_shell_safe_body_file_and_sub_issue_rules
+    - verify_live_external_writes_with_a_sandbox_or_low_impact_identity_before_claiming_connector_access_works
 
 research_policy:
   preferred_stack:
@@ -343,6 +371,9 @@ github_delivery_flow:
     - prefer_squash_merge_for_single_slice_history_unless_project_canon_overrides_it
     - auto_bug_intake_should_open_or_update_the_bug_issue_before_fix_delivery_begins
     - when_using_gh_issue_or_pr_commands_from_shell_prefer_body_file_over_inline_body
+    - prefer_mcp_or_app_connector_for_structured_github_issue_pr_and_metadata_operations_when_available_and_authorized
+    - local_gh_auth_and_github_app_connector_auth_are_different_identities_with_separate_permissions
+    - if_github_connector_returns_resource_not_accessible_by_integration_check_installed_github_app_repository_access_and_permissions
     - never_embed_markdown_with_backticks_in_inline_double_quoted_gh_body_arguments
     - single_quoted_heredoc_is_an_acceptable_fallback_only_when_it_writes_the_body_file_first
     - when_linking_sub_issues_from_cli_prefer_the_kernel_helper_or_graphql_addSubIssue_after_resolving_issue_node_ids
@@ -403,6 +434,7 @@ model_adapter_policy:
   shared_core_must_match:
     - prd_first_execution
     - agent_skill_orchestration_policy
+    - mcp_tooling_policy
     - github_issue_tree
     - verification_contract
     - documentation_discipline

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository is the standalone source-of-truth for:
 
 - PRD-first execution
 - Superpowers-compatible process-skill orchestration
+- MCP and App connector tooling policy
 - GitHub issue decomposition
 - PR verification discipline
 - project bootstrap templates
@@ -50,6 +51,7 @@ Shared core:
 - implementation
 - post-change verification
 - GitHub `Epic / Task / Bug` hierarchy
+- MCP or App connector use for supported structured external-service operations, with local `gh` fallback treated as a different identity
 - automatic deduplicated `Bug` intake from verifier/watchdog/runtime gates
 - PR closes leaf issue only
 - shell-safe GitHub CLI delivery through `--body-file` or a single-quoted heredoc-generated body file instead of inline markdown bodies
@@ -95,6 +97,14 @@ Skill-assisted execution canon:
 - map bugs, failed tests, and unexpected behavior to `systematic-debugging`
 - map completion claims to `verification-before-completion`
 - use `subagent-driven-development`, `dispatching-parallel-agents`, or `executing-plans` only when the platform, independence, and user or project policy allow it
+
+MCP tooling canon:
+
+- use MCP or App connector tooling for supported structured external-service operations when available and authorized
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- configure GitHub App repository access and permissions in GitHub Installed Apps, not by changing the local `gh` token
+- never record tokens in repo docs, PRDs, issues, or PR bodies
+- if the App connector is blocked or missing, use the canonical shell-safe `gh` fallback and record the gap when it affects the slice
 
 Kernel sync canon:
 
@@ -146,6 +156,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - thin behavior-layer policy for `CLAUDE.md` / Cursor / skill/plugin surfaces
 - [references/SUPERPOWERS_SKILL_ORCHESTRATION.md](references/SUPERPOWERS_SKILL_ORCHESTRATION.md)
   - how Superpowers and equivalent process skills should be used without replacing the kernel
+- [references/MCP_TOOLING.md](references/MCP_TOOLING.md)
+  - how MCP and App connector tooling should be used with GitHub App permissions and `gh` fallback boundaries
 - [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md)
   - local-first versus GitHub Actions execution policy
 - [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Universal engineering kernel for agent-led software work.
 This repository is the standalone source-of-truth for:
 
 - PRD-first execution
+- Superpowers-compatible process-skill orchestration
 - GitHub issue decomposition
 - PR verification discipline
 - project bootstrap templates
@@ -43,6 +44,7 @@ Shared core:
 - research
 - code audit
 - reconciliation
+- process-skill selection when Superpowers or an equivalent skill pack is available
 - documentation first
 - baseline verification when an existing contract already exists
 - implementation
@@ -81,6 +83,18 @@ Verification canon:
 - for docs-only, canon-only, or greenfield slices without an existing contract, do not invent a fake pre-change baseline
 - live verification that can write to an external service must use explicitly designated sandbox identities, never operator or production identities
 - post-change verification before publish remains mandatory
+
+Skill-assisted execution canon:
+
+- Superpowers skills are a tactical process layer, not a replacement for project canon
+- project-local `AGENTS.md`, the active PRD, explicit user instructions, tests, and the engineering kernel outrank skill defaults
+- when a relevant Superpowers skill is available, agents should read or invoke it before acting
+- map new behavior to `using-superpowers` and `brainstorming`
+- map approved multi-step work to `writing-plans`
+- map implementation and bugfixes to `test-driven-development`
+- map bugs, failed tests, and unexpected behavior to `systematic-debugging`
+- map completion claims to `verification-before-completion`
+- use `subagent-driven-development`, `dispatching-parallel-agents`, or `executing-plans` only when the platform, independence, and user or project policy allow it
 
 Kernel sync canon:
 
@@ -130,6 +144,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - model adapter policy
 - [references/BEHAVIORAL_OVERLAY.md](references/BEHAVIORAL_OVERLAY.md)
   - thin behavior-layer policy for `CLAUDE.md` / Cursor / skill/plugin surfaces
+- [references/SUPERPOWERS_SKILL_ORCHESTRATION.md](references/SUPERPOWERS_SKILL_ORCHESTRATION.md)
+  - how Superpowers and equivalent process skills should be used without replacing the kernel
 - [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md)
   - local-first versus GitHub Actions execution policy
 - [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,7 @@ Read [ENGINEERING_KERNEL.yaml](ENGINEERING_KERNEL.yaml) for the machine-readable
 Read [references/BOOTSTRAP.md](references/BOOTSTRAP.md) when you need to materialize the kernel into a project.
 Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user asks how the kernel should map across GPT/Codex and Claude-style agents.
 Read [references/BEHAVIORAL_OVERLAY.md](references/BEHAVIORAL_OVERLAY.md) when the user asks whether a thin behavior-only guideline layer should exist across `CLAUDE.md`, Cursor rules, or skill/plugin surfaces.
+Read [references/SUPERPOWERS_SKILL_ORCHESTRATION.md](references/SUPERPOWERS_SKILL_ORCHESTRATION.md) when the user asks how Superpowers or another process-skill pack should be used with the kernel.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
@@ -26,11 +27,19 @@ The bug-intake rule is explicit:
 - use one stable fingerprint per bug class
 - update the existing open bug issue when the fingerprint matches
 
+The minimum Superpowers mapping is explicit:
+
+- `using-superpowers` and `brainstorming` for new behavior
+- `writing-plans` for approved multi-step work
+- `test-driven-development` and `systematic-debugging` for implementation and bugs
+- `verification-before-completion` before success or PR-ready claims
+
 ## Use this skill for
 
 - creating a reusable engineering kernel for future projects
 - bootstrapping a new repository so agents stop depending on chat memory
 - establishing PRD-first execution
+- establishing Superpowers-compatible process-skill orchestration
 - establishing GitHub `Epic / Task / Bug` workflow
 - establishing automatic deduplicated GitHub bug intake
 - establishing Tavily Search-first research behavior, with Tavily Research reserved for justified expensive deep-sweeps
@@ -66,6 +75,7 @@ The bug-intake rule is explicit:
 2. Apply the minimal core before discussing maximum enforcement.
 - project canon
 - PRD-first execution
+- Superpowers-compatible skill orchestration when process skills are available
 - issue tree
 - local-first execution surface
 - kernel upstream awareness
@@ -102,5 +112,6 @@ Prefer a small durable set of outputs:
 - explicit bug-intake policy for verifier/watchdog/runtime incidents
 - explicit `kernel_impact` field in PRD/closeout flow
 - explicit `Kernel Impact` closeout decision after serious slices
+- explicit process-skill policy for Superpowers or equivalent skills
 
 Use the templates in [templates/project](templates/project) when bootstrapping a repo.

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,6 +12,7 @@ Read [references/BOOTSTRAP.md](references/BOOTSTRAP.md) when you need to materia
 Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user asks how the kernel should map across GPT/Codex and Claude-style agents.
 Read [references/BEHAVIORAL_OVERLAY.md](references/BEHAVIORAL_OVERLAY.md) when the user asks whether a thin behavior-only guideline layer should exist across `CLAUDE.md`, Cursor rules, or skill/plugin surfaces.
 Read [references/SUPERPOWERS_SKILL_ORCHESTRATION.md](references/SUPERPOWERS_SKILL_ORCHESTRATION.md) when the user asks how Superpowers or another process-skill pack should be used with the kernel.
+Read [references/MCP_TOOLING.md](references/MCP_TOOLING.md) when the user asks how MCP servers, App connector tooling, GitHub App permissions, or local `gh` fallback should be used.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
 Read [references/EXECUTION_SURFACES.md](references/EXECUTION_SURFACES.md) when the user asks where work should run locally versus in GitHub Actions or CI.
 Read [references/KERNEL_SYNC_POLICY.md](references/KERNEL_SYNC_POLICY.md) when the user asks how live project learnings should be reviewed and promoted back into the universal kernel.
@@ -34,12 +35,20 @@ The minimum Superpowers mapping is explicit:
 - `test-driven-development` and `systematic-debugging` for implementation and bugs
 - `verification-before-completion` before success or PR-ready claims
 
+The MCP tooling rule is explicit:
+
+- prefer MCP or App connector tooling for supported structured external-service operations
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- GitHub App repository access and permissions live in GitHub Installed Apps, not in the local `gh` token
+- use shell-safe `gh` fallback when the connector is missing or blocked
+
 ## Use this skill for
 
 - creating a reusable engineering kernel for future projects
 - bootstrapping a new repository so agents stop depending on chat memory
 - establishing PRD-first execution
 - establishing Superpowers-compatible process-skill orchestration
+- establishing MCP/App connector tooling boundaries and GitHub App permission checks
 - establishing GitHub `Epic / Task / Bug` workflow
 - establishing automatic deduplicated GitHub bug intake
 - establishing Tavily Search-first research behavior, with Tavily Research reserved for justified expensive deep-sweeps
@@ -78,6 +87,7 @@ The minimum Superpowers mapping is explicit:
 - Superpowers-compatible skill orchestration when process skills are available
 - issue tree
 - local-first execution surface
+- MCP/App connector tooling policy
 - kernel upstream awareness
 - kernel sync review
 - PR verification contract
@@ -113,5 +123,6 @@ Prefer a small durable set of outputs:
 - explicit `kernel_impact` field in PRD/closeout flow
 - explicit `Kernel Impact` closeout decision after serious slices
 - explicit process-skill policy for Superpowers or equivalent skills
+- explicit MCP/App connector policy with local `gh` fallback boundaries
 
 Use the templates in [templates/project](templates/project) when bootstrapping a repo.

--- a/docs/superpowers-skill-orchestration-prd-2026-04-26.md
+++ b/docs/superpowers-skill-orchestration-prd-2026-04-26.md
@@ -1,0 +1,99 @@
+# PRD: Superpowers Skill Orchestration
+
+Date: `2026-04-26`
+
+Status: `active`
+
+## GitHub Issues
+
+- Epic: #38
+- Task: #39
+
+## Problem
+
+The kernel already defines PRD-first, issue-first, verification-first engineering workflow, but it does not explicitly tell agents how to use Superpowers skills when they are available. That leaves a gap: a consumer project can have both the engineering kernel and Superpowers installed, yet the agent may treat them as unrelated systems.
+
+## Current State
+
+Verified facts:
+
+- `ENGINEERING_KERNEL.yaml` has policies for PRD-first execution, research, execution surfaces, GitHub delivery, kernel sync, and model adapters.
+- Project templates materialize `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, PRD templates, GitHub metadata, and sync scripts.
+- Superpowers skills installed locally include `using-superpowers`, `brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`, `using-git-worktrees`, `dispatching-parallel-agents`, `subagent-driven-development`, `executing-plans`, `finishing-a-development-branch`, and `writing-skills`.
+- No current kernel reference maps those skills into kernel priority, PRD-first execution, or project bootstrap.
+
+## Target State
+
+The kernel treats Superpowers as a tactical process-skill layer:
+
+- agents must read or invoke relevant skills before acting when they are available;
+- project-local canon, active PRD, tests, and explicit user instructions remain higher priority;
+- core Superpowers triggers are mapped to kernel phases;
+- subagent and parallel workflows require platform support and user or project permission;
+- consumer project templates inherit the rule without copying full vendor skill text.
+
+## Write Scope
+
+- `ENGINEERING_KERNEL.yaml`
+- `README.md`
+- `SKILL.md`
+- `CHANGELOG.md`
+- `references/SUPERPOWERS_SKILL_ORCHESTRATION.md`
+- `references/BOOTSTRAP.md`
+- `references/MODEL_ADAPTERS.md`
+- `references/BEHAVIORAL_OVERLAY.md`
+- `templates/project/AGENTS.md`
+- `templates/project/README.md`
+- `templates/project/CONTRIBUTING.md`
+- `templates/project/docs/PRD_TEMPLATE.md`
+- `tests/test_repo_kernel_canon.py`
+
+## Process Skills
+
+- available skill pack: `Superpowers`
+- relevant skills:
+  - `using-superpowers`
+  - `brainstorming`
+  - `writing-plans`
+  - `test-driven-development`
+  - `systematic-debugging`
+  - `verification-before-completion`
+- exceptions or conflicts with project canon: `none`
+
+## Kernel Upstream Check
+
+This change updates the kernel itself, not a downstream consumer repository.
+
+- protocol: `kernel_upstream_check`
+- status: `not_applicable`
+- action: `none`
+- `kernel_adoption_task`: `n/a`
+- adoption decision when drift exists: `not_applicable`
+
+## Rollout
+
+1. Add machine-readable `agent_skill_orchestration_policy`.
+2. Add a durable reference document.
+3. Update README, skill entrypoint, model adapter, bootstrap, behavioral overlay, and project templates.
+4. Add tests that pin the new canon across YAML, docs, and templates.
+5. Run the local unittest suite.
+
+## Verification Matrix
+
+- code-path tests: `.venv/bin/python -m unittest discover -s tests`
+- build/runtime checks: YAML parsing through existing tests
+- source-of-truth / sync checks: tests assert new reference and template coverage
+- live checks: not required; docs and tests only
+- rollback validation: revert the docs/templates/YAML/test changes as one slice if needed
+
+## Kernel Impact
+
+Record this during `kernel_sync_review`.
+
+Choose one:
+
+- `promote_to_kernel`
+
+Why:
+
+This slice adds a reusable process rule for every consumer project that combines the engineering kernel with Superpowers or another process-skill pack.

--- a/docs/superpowers-skill-orchestration-prd-2026-04-26.md
+++ b/docs/superpowers-skill-orchestration-prd-2026-04-26.md
@@ -11,7 +11,7 @@ Status: `active`
 
 ## Problem
 
-The kernel already defines PRD-first, issue-first, verification-first engineering workflow, but it does not explicitly tell agents how to use Superpowers skills when they are available. That leaves a gap: a consumer project can have both the engineering kernel and Superpowers installed, yet the agent may treat them as unrelated systems.
+The kernel already defines PRD-first, issue-first, verification-first engineering workflow, but it does not explicitly tell agents how to use Superpowers skills when they are available. It also does not define how MCP/App connector tooling relates to local CLI fallback. That leaves a gap: a consumer project can have the engineering kernel, Superpowers, an MCP-backed App connector, and a local `gh` token, yet the agent may treat them as unrelated or interchangeable systems.
 
 ## Current State
 
@@ -21,6 +21,7 @@ Verified facts:
 - Project templates materialize `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, PRD templates, GitHub metadata, and sync scripts.
 - Superpowers skills installed locally include `using-superpowers`, `brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`, `using-git-worktrees`, `dispatching-parallel-agents`, `subagent-driven-development`, `executing-plans`, `finishing-a-development-branch`, and `writing-skills`.
 - No current kernel reference maps those skills into kernel priority, PRD-first execution, or project bootstrap.
+- Live GitHub verification showed that GitHub App connector access and local `gh` access are different identities with separate permissions.
 
 ## Target State
 
@@ -32,6 +33,14 @@ The kernel treats Superpowers as a tactical process-skill layer:
 - subagent and parallel workflows require platform support and user or project permission;
 - consumer project templates inherit the rule without copying full vendor skill text.
 
+The kernel also treats MCP and App connector tooling as the preferred structured interface for supported external-service operations:
+
+- agents prefer MCP/App connector calls when available and authorized;
+- GitHub App repository access and permissions are checked in GitHub Installed Apps;
+- local `gh` auth and GitHub App connector auth are documented as different identities;
+- shell-safe `gh` fallback remains canonical when the connector is missing, stale, or blocked;
+- tokens are never recorded in repo docs, PRDs, issues, or PR bodies.
+
 ## Write Scope
 
 - `ENGINEERING_KERNEL.yaml`
@@ -39,6 +48,7 @@ The kernel treats Superpowers as a tactical process-skill layer:
 - `SKILL.md`
 - `CHANGELOG.md`
 - `references/SUPERPOWERS_SKILL_ORCHESTRATION.md`
+- `references/MCP_TOOLING.md`
 - `references/BOOTSTRAP.md`
 - `references/MODEL_ADAPTERS.md`
 - `references/BEHAVIORAL_OVERLAY.md`
@@ -74,16 +84,17 @@ This change updates the kernel itself, not a downstream consumer repository.
 
 1. Add machine-readable `agent_skill_orchestration_policy`.
 2. Add a durable reference document.
-3. Update README, skill entrypoint, model adapter, bootstrap, behavioral overlay, and project templates.
-4. Add tests that pin the new canon across YAML, docs, and templates.
-5. Run the local unittest suite.
+3. Add machine-readable `mcp_tooling_policy` and a durable MCP/App connector reference.
+4. Update README, skill entrypoint, model adapter, bootstrap, behavioral overlay, GitHub delivery, and project templates.
+5. Add tests that pin the new canon across YAML, docs, and templates.
+6. Run the local unittest suite.
 
 ## Verification Matrix
 
 - code-path tests: `.venv/bin/python -m unittest discover -s tests`
 - build/runtime checks: YAML parsing through existing tests
 - source-of-truth / sync checks: tests assert new reference and template coverage
-- live checks: not required; docs and tests only
+- live checks: GitHub connector issue creation was verified against `alexxety/agent-engineering-kernel` and the temporary issue was closed
 - rollback validation: revert the docs/templates/YAML/test changes as one slice if needed
 
 ## Kernel Impact
@@ -96,4 +107,4 @@ Choose one:
 
 Why:
 
-This slice adds a reusable process rule for every consumer project that combines the engineering kernel with Superpowers or another process-skill pack.
+This slice adds reusable process rules for every consumer project that combines the engineering kernel with Superpowers, MCP/App connector tooling, or local `gh` fallback.

--- a/references/BEHAVIORAL_OVERLAY.md
+++ b/references/BEHAVIORAL_OVERLAY.md
@@ -32,6 +32,8 @@ They must not replace:
 - `kernel_sync_review`
 - research classification
 
+Process-skill packs such as Superpowers are not merely behavioral overlays. They can provide task-specific workflows for brainstorming, planning, TDD, debugging, review, and verification. They still remain subordinate to project canon and must not replace the engineering kernel.
+
 ## Multi-surface sync rule
 
 If a project uses several agent surfaces, keep one canonical behavioral-overlay source and derive the rest from it.

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -45,6 +45,10 @@ The bootstrapped canon should also make explicit:
 - that active PRDs and closeouts carry a `Kernel Impact` decision
 - that Superpowers or equivalent process skills are tactical workflow aids, subordinate to repo canon, and should be read or invoked before acting when relevant and available
 - that the minimum Superpowers mapping includes `using-superpowers` for skill selection and `verification-before-completion` before success claims
+- that MCP or App connector tooling is preferred for supported structured external-service operations when available and authorized
+- that local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- that GitHub App repository access and permissions are configured in GitHub Installed Apps, not by storing or editing tokens in project files
+- that shell-safe `gh` fallback remains canonical when an App connector is missing, stale, or blocked
 - that the consumer project pins the exact kernel commit it bootstrapped from
 - that every `external_contract_slice` records an explicit `external_source_of_truth_matrix` in the active PRD or decision note
 - that any optional `CLAUDE.md` / Cursor rule / skill-style behavior overlay is thin, subordinate to repo canon, and synced from one canonical overlay source if the project chooses to use it
@@ -69,6 +73,8 @@ Do not blindly overwrite stronger project-local canon unless the task is an inte
 Do not treat a compact behavior guideline file as a replacement for the bootstrapped canon. If a project wants that extra layer, add it separately and keep it thin.
 
 Do not treat Superpowers or another process-skill pack as a replacement for the bootstrapped canon. Skills help the agent choose the right workflow; the project canon remains the source of truth.
+
+Do not treat MCP or App connector access as the same thing as local `gh` access. They are different identities. If a GitHub App connector fails with a permissions error, fix the installed GitHub App repository access and permissions before refreshing local CLI auth.
 
 Bootstrap should pin the current kernel commit into `.kernel/upstream.json` instead of leaving placeholder or branch-only metadata.
 

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -43,6 +43,8 @@ The bootstrapped canon should also make explicit:
 - that each serious slice begins with `kernel_upstream_check`
 - that each serious slice ends with `kernel_sync_review`
 - that active PRDs and closeouts carry a `Kernel Impact` decision
+- that Superpowers or equivalent process skills are tactical workflow aids, subordinate to repo canon, and should be read or invoked before acting when relevant and available
+- that the minimum Superpowers mapping includes `using-superpowers` for skill selection and `verification-before-completion` before success claims
 - that the consumer project pins the exact kernel commit it bootstrapped from
 - that every `external_contract_slice` records an explicit `external_source_of_truth_matrix` in the active PRD or decision note
 - that any optional `CLAUDE.md` / Cursor rule / skill-style behavior overlay is thin, subordinate to repo canon, and synced from one canonical overlay source if the project chooses to use it
@@ -65,6 +67,8 @@ python3 scripts/sync_github_labels.py --apply
 Do not blindly overwrite stronger project-local canon unless the task is an intentional migration.
 
 Do not treat a compact behavior guideline file as a replacement for the bootstrapped canon. If a project wants that extra layer, add it separately and keep it thin.
+
+Do not treat Superpowers or another process-skill pack as a replacement for the bootstrapped canon. Skills help the agent choose the right workflow; the project canon remains the source of truth.
 
 Bootstrap should pin the current kernel commit into `.kernel/upstream.json` instead of leaving placeholder or branch-only metadata.
 

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -10,6 +10,13 @@ Execution-surface rule:
 - GitHub Actions are for repository-native automation, scheduled/event jobs, deploys, and hosted verification that must live in the platform
 - paid GitHub-hosted runners, dependency caches, and long-lived artifacts in private repositories require an explicit PRD/decision note that accepts the paid surface
 
+Tooling rule:
+
+- use MCP or App connector tooling for supported structured GitHub issue, pull request, review, and metadata operations when available and authorized
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- if the App connector returns `Resource not accessible by integration`, check the installed GitHub App repository access and permissions before refreshing the local `gh` token
+- when the connector is unavailable, stale, or missing a needed operation, use the shell-safe `gh` fallback below
+
 ## Canonical sequence
 
 1. Create or update the PRD
@@ -40,6 +47,8 @@ Execution-surface rule:
   - `defer`
   - `not_applicable`
 - when using `gh issue create`, `gh issue edit`, or `gh pr create` from shell, prefer `--body-file` over inline `--body`
+- when MCP or an App connector can do the structured write, prefer it over shelling out, then verify the connector path itself
+- do not treat a working local `gh` token as proof that the GitHub App connector has repository access or write permissions
 - never embed markdown with backticks or fenced code blocks in inline double-quoted `gh --body` arguments
 - acceptable fallback is a single-quoted heredoc such as `<<'EOF'` that writes the body file first
 - when linking GitHub sub-issues from the CLI, prefer `scripts/link_github_sub_issue.py` or GraphQL `addSubIssue` after resolving issue node ids
@@ -53,3 +62,5 @@ Execution-surface rule:
 The branch/PR layer is part of the engineering kernel, not a separate afterthought. It prevents code from landing without an issue tree, verification, and an auditable review surface.
 
 It also has to survive the shell. Inline markdown bodies are fragile in `zsh` because backticks trigger command substitution. `--body-file` keeps GitHub delivery deterministic and prevents the shell from executing or corrupting issue/PR body content.
+
+It also has to survive multiple identities. MCP-backed App connector tokens, GitHub App installation tokens, and local `gh` tokens are different identities; diagnose permission failures on the identity that actually made the failed request.

--- a/references/MCP_TOOLING.md
+++ b/references/MCP_TOOLING.md
@@ -1,0 +1,61 @@
+# MCP Tooling Policy
+
+Use this when a project has MCP servers, app integrations, or an App connector for an external service.
+
+## Purpose
+
+MCP and App connector tooling is the preferred structured interface for supported external-service operations. It should be used for repository, issue, pull request, review, CI, search, or vendor-data operations when the connector has the needed capability and permissions.
+
+The connector is not the project canon, not a secret store, and not a reason to skip PRD-first or verification-first work.
+
+## Identity Boundaries
+
+Treat these as different identities:
+
+- MCP server or App connector token
+- GitHub App installation token
+- local `gh` CLI token
+- personal access token
+- service account or sandbox identity
+
+Local `gh` auth and GitHub App connector auth are different identities with separate permissions. A working `gh auth status` does not prove that the App connector can create issues or pull requests. A connector `403 Resource not accessible by integration` usually points at the installed GitHub App repository access or App permissions, not the local `gh` token.
+
+Do not paste or record tokens in repo docs, PRDs, issue bodies, or chat transcripts. Record the identity class and permission surface, not the secret.
+
+## GitHub App Connector Minimums
+
+For GitHub delivery through an MCP-backed App connector, the installed GitHub App should have access to the target repository and the minimum permissions for the operation:
+
+- repository access to the target repo, or all repositories when the operator intentionally chooses that broader scope
+- `Contents: Read and write` when the connector changes code, branches, files, or workflow files
+- `Issues: Read and write` when it creates or updates issues
+- `Pull requests: Read and write` when it creates or updates pull requests
+- `Actions` or `Workflows: Read and write` only when action state or workflow files are in scope
+
+If the connector fails with a permission error, check the installed GitHub App first: `GitHub Settings -> Applications -> Installed GitHub Apps -> Configure`. Confirm repository access and the requested permissions there before refreshing the local `gh` token.
+
+## Preferred Flow
+
+1. Use the MCP server or App connector for structured operations it supports.
+2. Check that the connector identity has repository access and write permissions before assuming a token problem.
+3. If the connector is unavailable, incomplete, stale, or blocked, use the canonical CLI fallback.
+4. Keep the fallback shell-safe: use `gh --body-file`, single-quoted heredoc-generated body files, and the kernel sub-issue helper when normal issue numbers must be linked.
+5. Record the capability gap in the active PRD, issue, or closeout when it changes execution, verification, or operator setup.
+
+## Verification
+
+Live external writes require evidence. Prefer low-impact checks:
+
+- list or read through the connector when a read permission is enough
+- create a temporary sandbox issue or branch only when write permission must be proven
+- close or clean up temporary verification artifacts immediately
+- never use production identities as test identities when sandbox identities are required
+
+Do not claim MCP or App connector access works only because local CLI access works. Verify the connector path itself.
+
+## Non-goals
+
+- Do not store tokens in the repository.
+- Do not replace project-local canon, active PRDs, or verification contracts with connector defaults.
+- Do not require MCP for every project; use it when available and useful.
+- Do not create a separate engineering workflow for each connector. Adapt only the tool surface.

--- a/references/MODEL_ADAPTERS.md
+++ b/references/MODEL_ADAPTERS.md
@@ -10,6 +10,7 @@ The engineering kernel is shared. The model adapter is thin.
 - PR closes leaf issue only
 - docs updated in the same slice
 - verification matrix and rollback discipline
+- MCP or App connector use for structured external-service operations, with local `gh` fallback treated as a different identity
 
 ## Allowed to differ by model
 
@@ -19,6 +20,7 @@ The engineering kernel is shared. The model adapter is thin.
 - verbosity and final report style
 - local skills/plugins/integrations
 - how Superpowers or equivalent process skills are invoked or surfaced
+- which MCP server or App connector surfaces are available
 - whether a thin behavior-only overlay is materialized in a tool-specific surface
 
 ## Behavioral overlay rule
@@ -53,6 +55,14 @@ If one platform has a skill tool and another only has markdown instructions, kee
 Process skills remain lower priority than project canon, the active PRD, tests, and explicit user instructions.
 
 The shared meaning includes `using-superpowers` for skill selection and `verification-before-completion` before success claims when Superpowers is available.
+
+## MCP/App connector adapter rule
+
+MCP servers and App connector integrations are tool surfaces, not separate engineering processes. Use them for supported structured operations when available and authorized.
+
+Local `gh` auth and GitHub App connector auth are different identities with separate permissions. A platform may expose GitHub through an MCP-backed App connector, while another agent only has `gh`; both must preserve the same issue-first, PRD-first, verification-first workflow.
+
+If a GitHub App connector is missing or blocked, use the canonical shell-safe `gh` fallback and record the gap when it affects the slice. Do not copy tokens between adapters or store them in repo files.
 
 ## Hard rule
 

--- a/references/MODEL_ADAPTERS.md
+++ b/references/MODEL_ADAPTERS.md
@@ -18,6 +18,7 @@ The engineering kernel is shared. The model adapter is thin.
 - shell/editor constraints
 - verbosity and final report style
 - local skills/plugins/integrations
+- how Superpowers or equivalent process skills are invoked or surfaced
 - whether a thin behavior-only overlay is materialized in a tool-specific surface
 
 ## Behavioral overlay rule
@@ -35,6 +36,23 @@ But it must stay:
 - lower priority than the repo-local canon and the shared engineering kernel
 
 Do not confuse a behavior overlay with the engineering workflow itself.
+
+## Process-skill adapter rule
+
+Superpowers or another process-skill pack may provide model-specific invocation mechanics, but the workflow intent stays shared:
+
+- design before implementation
+- explicit plan before multi-step edits
+- TDD for implementation and bugfixes
+- systematic debugging before fixes
+- fresh verification before completion claims
+- review before merge or handoff
+
+If one platform has a skill tool and another only has markdown instructions, keep the same meaning and adapt only the invocation surface.
+
+Process skills remain lower priority than project canon, the active PRD, tests, and explicit user instructions.
+
+The shared meaning includes `using-superpowers` for skill selection and `verification-before-completion` before success claims when Superpowers is available.
 
 ## Hard rule
 

--- a/references/SUPERPOWERS_SKILL_ORCHESTRATION.md
+++ b/references/SUPERPOWERS_SKILL_ORCHESTRATION.md
@@ -1,0 +1,77 @@
+# Superpowers Skill Orchestration
+
+Use this reference when a project has Superpowers or an equivalent process-skill pack available.
+
+## Purpose
+
+The engineering kernel defines the operating system: PRD-first work, issue hierarchy, research policy, verification, delivery, and kernel sync.
+
+Superpowers skills are the tactical agent workflow layer. They tell the agent how to execute a moment of work without replacing the repo-local canon.
+
+## Priority
+
+Follow this order:
+
+1. Direct user instruction
+2. Project-local canon and active PRD
+3. Engineering kernel
+4. Applicable Superpowers or equivalent process skill
+5. Model default behavior
+
+If a Superpowers skill conflicts with the active PRD, `AGENTS.md`, repository tests, or an explicit user instruction, follow the higher-priority source and record the exception when it affects the slice.
+
+## Required Skill Check
+
+When a relevant Superpowers skill is available, the agent must read or invoke it before acting.
+
+If skill tooling is unavailable, the agent still applies the same principles manually:
+
+- design before implementation for new behavior
+- explicit plan before multi-step edits
+- TDD for implementation and bugfixes
+- systematic root-cause investigation before fixes
+- fresh verification before completion claims
+- review before merge or handoff
+
+Record the tooling gap in the active PRD, plan, or closeout only when it changes the work or verification.
+
+## Canonical Mapping
+
+Use `using-superpowers` at conversation start when the platform exposes it.
+
+Use `brainstorming` when the task creates or changes behavior, UI, architecture, workflows, or project structure. Its output should reconcile with the project PRD or decision-doc location; do not create a parallel spec system if the project already has one.
+
+Use `writing-plans` after a spec or requirement set exists and the work has multiple steps. Plans must reference exact files, verification commands, and rollback expectations.
+
+Use `test-driven-development` before implementation code for features and bugfixes, except for documented exceptions such as pure docs, generated code, or throwaway prototypes.
+
+Use `systematic-debugging` for bugs, failed tests, build failures, regressions, and unexpected behavior before proposing fixes.
+
+Use `using-git-worktrees` when the work needs branch isolation or when executing an implementation plan. Project branch/worktree policy remains higher priority.
+
+Use `dispatching-parallel-agents` only for independent problem domains with no shared write scope.
+
+Use `subagent-driven-development` for independent plan tasks only when the platform supports subagents and the user or project policy permits them. Otherwise use `executing-plans`.
+
+Use `requesting-code-review` before merge or after major tasks, and `receiving-code-review` before implementing review feedback.
+
+Use `verification-before-completion` before any success, fixed, passing, done, commit-ready, or PR-ready claim.
+
+Use `finishing-a-development-branch` after implementation is complete and verification is fresh.
+
+Use `writing-skills` when creating or modifying reusable skills.
+
+## Non-Goals
+
+Do not vendor-copy Superpowers skill text into project canon when a short mapping is enough.
+
+Do not let a skill pack bypass:
+
+- PRD-first execution
+- GitHub `Epic / Task / Bug`
+- `kernel_upstream_check`
+- `kernel_sync_review`
+- external-contract research requirements
+- the project verification matrix
+
+Do not run subagent or parallel workflows merely because a skill mentions them. They require platform support, clear independence, and user or project permission.

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -60,6 +60,15 @@ Rules:
 - if a known URL already exists, fetch/index it directly instead of re-running broad search
 - distinguish verified facts from assumptions
 
+## MCP/App connector canon
+
+- use MCP or App connector tooling for supported structured external-service operations when available and authorized
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- configure GitHub App repository access and permissions in GitHub Installed Apps, not by storing or editing tokens in repo files
+- if an App connector returns a permission error, check its repository access and permissions before refreshing local `gh` auth
+- use shell-safe `gh` fallback when connector tooling is unavailable, stale, or missing the needed operation
+- do not paste or record tokens in PRDs, issues, PR bodies, or project docs
+
 ## Execution surface canon
 
 - prefer the local operator machine first for ordinary development, debugging, research, and verification
@@ -100,6 +109,7 @@ Rules:
 - use sub-issues for multi-slice work
 - PR closes the leaf issue only, not the parent epic
 - when invoking `gh issue create`, `gh issue edit`, or `gh pr create` from shell, use `--body-file` instead of inline double-quoted `--body`
+- prefer MCP or App connector writes for GitHub issue/PR operations when the connector has the needed GitHub App permissions
 - if a file is inconvenient, write it first with a single-quoted heredoc such as `<<'EOF'`
 - when linking sub-issues from CLI, prefer `scripts/link_github_sub_issue.py` or GraphQL `addSubIssue` after resolving issue node ids
 - if REST is used directly, `sub_issue_id` means child issue database id, not `#issue_number`

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -12,6 +12,40 @@ This repository follows the agent engineering kernel.
 6. Implementation
 7. Post-change verification
 
+## Skill-assisted execution canon
+
+If Superpowers or an equivalent process-skill pack is available, agents must read or invoke the relevant skill before acting.
+
+Priority order:
+
+1. Direct user instruction
+2. This project-local canon and the active PRD
+3. The engineering kernel
+4. Applicable Superpowers or equivalent process skill
+5. Model default behavior
+
+Canonical mapping:
+
+- new behavior, feature design, UI, workflow, or architecture: `using-superpowers`, then `brainstorming`
+- approved spec or multi-step requirements: `writing-plans`
+- implementation or bugfix: `test-driven-development`
+- bug, failed test, build failure, regression, or unexpected behavior: `systematic-debugging`
+- isolated branch or plan execution workspace: `using-git-worktrees`
+- independent parallel problem domains: `dispatching-parallel-agents`
+- implementation plan with permitted subagents: `subagent-driven-development`
+- implementation plan without subagents: `executing-plans`
+- code review request or review response: `requesting-code-review`, `receiving-code-review`
+- success, fixed, passing, done, commit-ready, or PR-ready claim: `verification-before-completion`
+- verified branch completion: `finishing-a-development-branch`
+
+Rules:
+
+- Superpowers skills are tactical workflow aids, not a replacement for PRD-first, issue-first, verification, or kernel-sync discipline.
+- The project canon remains the source of truth for requirements, scope, and verification.
+- If a skill default conflicts with this canon, the active PRD, tests, or an explicit user instruction, follow the higher-priority source and record the exception when it affects the slice.
+- If skill tooling is unavailable, apply the same principles manually and record the gap only when it changes the work or verification.
+- Do not run subagent or parallel workflows unless the platform supports them and user or project policy permits them.
+
 ## Research canon
 
 - use Tavily Search first, not Tavily Research first
@@ -117,6 +151,7 @@ If this repository also uses a thin behavior-only layer such as `CLAUDE.md`, a C
 - keep it optional and thin;
 - keep one canonical overlay source if several derived variants exist;
 - treat this `AGENTS.md`, the PRD, tests, and repo-local canon as higher priority than that overlay.
+- treat process-skill packs such as Superpowers as workflow aids, not as replacements for this canon.
 
 ## Canon files
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -16,6 +16,14 @@ If Superpowers or an equivalent process-skill pack is available, agents should r
 
 Skills are tactical workflow aids. This project canon, the active PRD, tests, and explicit user instructions stay higher priority.
 
+## MCP/App connector policy
+
+- use MCP or App connector tooling for supported structured external-service operations when available and authorized
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- configure GitHub App repository access and permissions in GitHub Installed Apps, not by storing tokens in repo files
+- if an App connector fails with a permission error, check repository access and App permissions before refreshing local `gh` auth
+- use the canonical shell-safe `gh` fallback when connector tooling is missing, stale, or blocked
+
 ## Research policy
 
 - Tavily Search first, not Tavily Research first

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 This repository uses a PRD-first and issue-first engineering workflow.
 
+## Process skill policy
+
+If Superpowers or an equivalent process-skill pack is available, agents should read or invoke the relevant skill before acting:
+
+- `using-superpowers` and `brainstorming` for new behavior or design work
+- `writing-plans` for approved multi-step work
+- `test-driven-development` for implementation and bugfixes
+- `systematic-debugging` for bugs, failed tests, build failures, regressions, or unexpected behavior
+- `verification-before-completion` before any success, fixed, passing, done, commit-ready, or PR-ready claim
+- `requesting-code-review` and `receiving-code-review` around review
+- `using-git-worktrees`, `dispatching-parallel-agents`, `subagent-driven-development`, or `executing-plans` only when the project, platform, and work shape allow them
+
+Skills are tactical workflow aids. This project canon, the active PRD, tests, and explicit user instructions stay higher priority.
+
 ## Research policy
 
 - Tavily Search first, not Tavily Research first

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -7,6 +7,9 @@ This repository follows the agent engineering kernel.
 - non-trivial work is PRD-first
 - Superpowers or equivalent process skills are used as tactical workflow aids when available, without replacing project canon
 - non-trivial work starts from a parent GitHub issue
+- MCP or App connector tooling is preferred for supported structured external-service operations when available and authorized
+- local `gh` auth and GitHub App connector auth are different identities with separate permissions
+- GitHub App repository access and permissions are configured in GitHub Installed Apps, not in repo files or local `gh` token settings
 - each non-trivial slice is classified before edits as `repo_local_slice` or `external_contract_slice`
 - repo-owned slices may proceed from project truth, deterministic verification, and local runtime checks
 - slices that change or claim current external-system behavior require fresh external research before code or docs land
@@ -37,6 +40,7 @@ This repository follows the agent engineering kernel.
 - PR closes the leaf issue only
 - agents should read or invoke relevant Superpowers skills before acting: `using-superpowers` / `brainstorming` for new behavior, `writing-plans` for multi-step work, `test-driven-development` for implementation, `systematic-debugging` for bugs, and `verification-before-completion` before success claims
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
+- shell-safe `gh` is the fallback when MCP/App connector tooling is missing, stale, or blocked
 - for GitHub sub-issues, prefer `scripts/link_github_sub_issue.py`; if you call REST directly, `sub_issue_id` means child issue database id, not `#issue_number`
 - GitHub Projects are optional and should be adopted only when issue-first execution needs shared fields/views or cross-repo planning
 - any optional `CLAUDE.md` / Cursor / skill-style behavior overlay must stay thin and subordinate to the repo-local canon

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -5,6 +5,7 @@ This repository follows the agent engineering kernel.
 ## Engineering canon
 
 - non-trivial work is PRD-first
+- Superpowers or equivalent process skills are used as tactical workflow aids when available, without replacing project canon
 - non-trivial work starts from a parent GitHub issue
 - each non-trivial slice is classified before edits as `repo_local_slice` or `external_contract_slice`
 - repo-owned slices may proceed from project truth, deterministic verification, and local runtime checks
@@ -34,6 +35,7 @@ This repository follows the agent engineering kernel.
 - every serious slice ends with `kernel_sync_review`
 - serious closeouts record `Kernel Impact`
 - PR closes the leaf issue only
+- agents should read or invoke relevant Superpowers skills before acting: `using-superpowers` / `brainstorming` for new behavior, `writing-plans` for multi-step work, `test-driven-development` for implementation, `systematic-debugging` for bugs, and `verification-before-completion` before success claims
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
 - for GitHub sub-issues, prefer `scripts/link_github_sub_issue.py`; if you call REST directly, `sub_issue_id` means child issue database id, not `#issue_number`
 - GitHub Projects are optional and should be adopted only when issue-first execution needs shared fields/views or cross-repo planning

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -33,6 +33,20 @@ What should be true after the change.
 
 Files, workflows, services, or systems expected to change.
 
+## Process Skills
+
+Record relevant Superpowers or equivalent process skills for this slice.
+
+- available skill pack: `Superpowers | other | unavailable`
+- relevant skills:
+  - `using-superpowers`
+  - `brainstorming`
+  - `writing-plans`
+  - `test-driven-development`
+  - `systematic-debugging`
+  - `verification-before-completion`
+- exceptions or conflicts with project canon: `none | describe`
+
 ## Kernel Upstream Check
 
 Record near slice start.

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -47,6 +47,17 @@ Record relevant Superpowers or equivalent process skills for this slice.
   - `verification-before-completion`
 - exceptions or conflicts with project canon: `none | describe`
 
+## MCP / App Connector Surface
+
+Record external-service tooling and identity boundaries when the slice uses GitHub, vendor APIs, or other live services.
+
+- MCP or App connector in scope: `none | name`
+- GitHub App repository access checked: `n/a | yes | no`
+- required App connector permissions: `n/a | issues:write | pull_requests:write | contents:write | workflows:write | describe`
+- local `gh` fallback required: `no | yes, reason`
+- identity note: `MCP/App connector and local gh are different identities`
+- token handling: `no tokens recorded`
+
 ## Kernel Upstream Check
 
 Record near slice start.

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -25,6 +25,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/BOOTSTRAP.md",
             "references/BEHAVIORAL_OVERLAY.md",
             "references/SUPERPOWERS_SKILL_ORCHESTRATION.md",
+            "references/MCP_TOOLING.md",
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
             "references/KERNEL_FLEET_SWEEP.md",
@@ -44,6 +45,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("layers", payload)
         self.assertIn("model_adapter_policy", payload)
         self.assertIn("agent_skill_orchestration_policy", payload)
+        self.assertIn("mcp_tooling_policy", payload)
         self.assertIn("research_policy", payload)
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
@@ -98,6 +100,17 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn(
             "every_external_contract_slice_must_record_an_external_source_of_truth_matrix_before_implementation_lands",
             research_policy["rules"],
+        )
+        mcp_policy = payload["mcp_tooling_policy"]
+        self.assertIn("structured_external_service_interface", mcp_policy["role"])
+        self.assertIn("github_app_installation_token", mcp_policy["identity_boundaries"])
+        self.assertIn(
+            "prefer_mcp_or_app_connector_for_supported_structured_external_service_operations",
+            mcp_policy["rules"],
+        )
+        self.assertIn(
+            "local_cli_tokens_and_mcp_connector_tokens_are_different_identities",
+            mcp_policy["rules"],
         )
 
     def test_kernel_readme_and_templates_document_pre_change_baseline_rule(self) -> None:
@@ -252,6 +265,26 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("heredoc", content, rel)
             self.assertIn("sub_issue_id", content, rel)
             self.assertIn("database id", content, rel)
+
+    def test_kernel_docs_and_templates_mention_mcp_tooling_policy(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/MCP_TOOLING.md",
+            "references/GITHUB_DELIVERY.md",
+            "references/BOOTSTRAP.md",
+            "references/MODEL_ADAPTERS.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("MCP", content, rel)
+            self.assertIn("App connector", content, rel)
+            self.assertIn("GitHub App", content, rel)
+            self.assertIn("gh", content, rel)
+            self.assertIn("different identities", content, rel)
 
     def test_kernel_docs_and_templates_mention_optional_github_projects(self) -> None:
         for rel in (

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -24,6 +24,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "scripts/link_github_sub_issue.py",
             "references/BOOTSTRAP.md",
             "references/BEHAVIORAL_OVERLAY.md",
+            "references/SUPERPOWERS_SKILL_ORCHESTRATION.md",
             "references/BUG_INTAKE.md",
             "references/EXECUTION_SURFACES.md",
             "references/KERNEL_FLEET_SWEEP.md",
@@ -42,6 +43,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         payload = yaml.safe_load((ROOT / "ENGINEERING_KERNEL.yaml").read_text(encoding="utf-8"))
         self.assertIn("layers", payload)
         self.assertIn("model_adapter_policy", payload)
+        self.assertIn("agent_skill_orchestration_policy", payload)
         self.assertIn("research_policy", payload)
         self.assertIn("github_delivery_flow", payload)
         self.assertIn("automatic_bug_intake", payload)
@@ -58,6 +60,17 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn(
             "capture_smallest_relevant_baseline_verification_before_edits_when_existing_contract_exists",
             prd_first["rules"],
+        )
+        skill_policy = payload["agent_skill_orchestration_policy"]
+        self.assertEqual(skill_policy["preferred_skill_pack"], "Superpowers")
+        self.assertIn("using-superpowers", skill_policy["canonical_skill_triggers"]["project_or_feature_design"])
+        self.assertIn(
+            "verification-before-completion",
+            skill_policy["canonical_skill_triggers"]["completion_claim_or_pr_ready"],
+        )
+        self.assertIn(
+            "project_local_canon_active_prd_and_explicit_user_instructions_override_skill_defaults",
+            skill_policy["rules"],
         )
         research_policy = payload["research_policy"]
         self.assertIn("slice_classification", research_policy)
@@ -308,6 +321,24 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("thin", content.lower(), rel)
             self.assertIn("Cursor", content, rel)
             self.assertIn("CLAUDE.md", content, rel)
+
+    def test_kernel_docs_and_templates_mention_superpowers_skill_orchestration(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/SUPERPOWERS_SKILL_ORCHESTRATION.md",
+            "references/BOOTSTRAP.md",
+            "references/MODEL_ADAPTERS.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("Superpowers", content, rel)
+            self.assertIn("using-superpowers", content, rel)
+            self.assertIn("verification-before-completion", content, rel)
+            self.assertIn("project canon", content, rel)
 
     def test_kernel_docs_and_templates_mention_kernel_adoption_task(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary

- Adds `agent_skill_orchestration_policy` to the machine-readable kernel.
- Adds `mcp_tooling_policy` to define MCP/App connector use, GitHub App permission checks, token identity boundaries, and shell-safe `gh` fallback.
- Adds `references/SUPERPOWERS_SKILL_ORCHESTRATION.md`, `references/MCP_TOOLING.md`, and a PRD/decision record for the slice.
- Updates bootstrap templates so consumer projects inherit Superpowers-compatible skill guidance and MCP/App connector guidance.
- Extends canon tests to pin the new policies across YAML, docs, and templates.

## Linked issue

Closes #39
Parent / context: #38

## Scope

Kernel docs, project templates, machine-readable YAML, changelog, and canon tests.

## Verification

- `.venv/bin/python -m unittest discover -s tests` -> 35 tests OK
- `git diff --check HEAD~1 HEAD` -> no whitespace errors
- GitHub connector write check: temporary issue #41 was created through the connector and immediately closed

## Rollback

Revert commits `0432d81` and `33905f5` to remove the Superpowers orchestration policy, MCP/App connector policy, references, PRD, template updates, and tests as one slice.
