### PR TITLE
docs: define subagent thread lifecycle canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added agentic coding orchestration canon: orchestrator/worker/reviewer roles, subagent concurrency limits, prompt write-set contract, review boundaries, and recovery protocol for executor resource failures.
 - Added project-local no-MCP worker canon and templates so rich-MCP orchestrators can dispatch lightweight implementation workers with global fallback behavior.
+- Added explicit subagent thread lifecycle rules: same-patch worker fix loops, one-shot reviewers, fresh re-reviewers, and required `thread_disposition` in final responses.
 - Added Superpowers-compatible process-skill orchestration to the kernel canon and project templates.
 - Added MCP/App connector tooling policy, including GitHub App permission checks, different identities for connector versus local `gh`, and shell-safe fallback behavior.
 - Research policy is now explicitly Tavily Search-first, not Tavily Research-first. Tavily Research is reserved for explicitly justified expensive broad deep-sweeps after search, known official docs, and manual synthesis are insufficient.

--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -173,6 +173,17 @@ agentic_coding_orchestration_policy:
     - avoid_broad_repeated_file_scans_unless_needed
     - do_not_busy_poll_agents
     - close_completed_or_abandoned_agent_threads_immediately_after_recording_result
+  thread_lifecycle_rules:
+    - implementation_worker_thread_is_kept_open_only_for_same_patch_review_fix_loop
+    - close_implementation_worker_after_patch_accepted_rejected_blocked_or_orchestrator_takes_over
+    - close_worker_when_next_task_has_different_write_set_or_prd_slice
+    - reviewer_explorer_and_docs_specialist_threads_are_single_use_by_default
+    - use_fresh_reviewer_for_re_review_after_fixes
+    - every_subagent_final_response_includes_thread_disposition
+  thread_disposition_values:
+    - parent_may_close_thread
+    - keep_open_for_same_patch_fix_loop
+    - blocked_needs_context
   recovery_triggers:
     - too_many_open_files
     - stream_disconnected_before_completion
@@ -220,6 +231,7 @@ project_local_worker_policy:
     - include_only_durable_project_rules_not_chat_memory_or_secrets
     - include_project_canon_path_live_access_policy_forbidden_actions_privacy_rules_allowed_local_checks_and_needs_context_rule
     - keep_worker_config_small_and_use_project_docs_skills_runbooks_handoffs_for_domain_knowledge
+    - require_thread_disposition_in_worker_final_response
     - dispatch_prompt_names_task_specific_docs_skills_runbooks_or_handoffs_to_read
     - disable_current_project_or_operator_mcp_server_ids_in_worker_config
     - disabled_mcp_entries_still_include_command_or_url_transport_to_avoid_invalid_transport_loader_errors

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Agentic coding orchestration canon:
 - run at most two worker agents concurrently, and only when write sets and runtime resources are disjoint
 - run reviewer agents selectively for security, DB, runtime/deploy, privacy/logging, production integration, or broad multi-file changes
 - keep at most three subagent threads open and close completed threads immediately
+- keep implementation workers open only for the same-patch review/fix loop; treat reviewers as one-shot and require `thread_disposition` in subagent final responses
 - avoid parallel shell/tool calls while worker agents are active
 - stop spawning agents and recover sequentially after executor/resource failures such as `Too many open files` or stream disconnects
 - resume only after `git status --short --branch` and `git diff --check` can run

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,6 +46,9 @@ The agentic coding orchestration rule is explicit:
 - default to one worker agent at a time
 - use at most two parallel worker agents only with disjoint write sets and healthy local executor state
 - close completed subagent threads promptly
+- keep implementation workers open only for the same-patch review/fix loop
+- treat reviewer/explorer/docs-specialist threads as one-shot and use fresh reviewers for re-review
+- require subagent final responses to include `thread_disposition`
 - avoid parallel shell/tool calls while worker agents are active
 - stop spawning agents and recover sequentially after executor/resource failures such as `Too many open files`
 - resume only after `git status --short --branch` and `git diff --check` can run

--- a/references/AGENTIC_CODING_ORCHESTRATION.md
+++ b/references/AGENTIC_CODING_ORCHESTRATION.md
@@ -104,6 +104,44 @@ Keep at most three subagent threads open:
 
 Close completed or abandoned agents immediately after recording their result.
 
+## Thread Lifecycle Rules
+
+Do not keep subagent threads open for memory. Keep them open only while the
+same bounded task still needs the same thread.
+
+Implementation workers may stay open through their own review/fix loop:
+
+- worker returns a patch or red-state report;
+- orchestrator inspects the diff and runs the required post-worker checks;
+- optional reviewer finds a concrete issue in that same patch;
+- orchestrator asks the same worker to fix the issue only if the write set,
+  task boundary, and file state are still the same.
+
+Close an implementation worker immediately after any of these happen:
+
+- the patch is accepted or rejected;
+- the orchestrator takes over the fix locally;
+- the next task has a different write set or different PRD slice;
+- the worker returns `NEEDS_CONTEXT` or `BLOCKED` and the answer was recorded;
+- executor health degrades and recovery mode begins.
+
+Reviewer, explorer, and docs-specialist threads are single-use by default.
+Record their result, then close the thread. After a fix, spawn a fresh reviewer
+with the current diff and context instead of preserving the old reviewer
+thread.
+
+Every subagent final response should include thread disposition:
+
+```text
+thread_disposition:
+- parent_may_close_thread
+- keep_open_for_same_patch_fix_loop
+- blocked_needs_context
+```
+
+If the disposition is not explicitly `keep_open_for_same_patch_fix_loop`, the
+orchestrator should close the thread after recording the result.
+
 ## Tool And Shell Load Rules
 
 While any worker agent is active:
@@ -187,6 +225,7 @@ Return:
 - changed files
 - commands run
 - concerns
+- thread_disposition: parent_may_close_thread / keep_open_for_same_patch_fix_loop / blocked_needs_context
 ```
 
 ## Integration Rules

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -49,7 +49,7 @@ The bootstrapped canon should also make explicit:
 - that active PRDs and closeouts carry a `Kernel Impact` decision
 - that Superpowers or equivalent process skills are tactical workflow aids, subordinate to repo canon, and should be read or invoked before acting when relevant and available
 - that the minimum Superpowers mapping includes `using-superpowers` for skill selection and `verification-before-completion` before success claims
-- that orchestrated agentic coding has one accountable orchestrator, one worker by default, at most two parallel workers with disjoint write sets, targeted reviewer agents, prompt write-set contracts, and a recovery protocol for executor/resource failures such as `Too many open files`
+- that orchestrated agentic coding has one accountable orchestrator, one worker by default, at most two parallel workers with disjoint write sets, targeted reviewer agents, prompt write-set contracts, same-patch worker thread lifecycle, one-shot reviewers, `thread_disposition`, and a recovery protocol for executor/resource failures such as `Too many open files`
 - that rich-MCP orchestrators should dispatch project-local no-MCP coding workers when custom agents are available, with the global `code_worker_no_mcp` only as fallback
 - that MCP or App connector tooling is preferred for supported structured external-service operations when available and authorized
 - that local `gh` auth and GitHub App connector auth are different identities with separate permissions

--- a/references/PROJECT_LOCAL_WORKERS.md
+++ b/references/PROJECT_LOCAL_WORKERS.md
@@ -139,6 +139,10 @@ secrets, or change files outside the assigned write set.
 Do not use MCP servers. If a task needs external research, live service access,
 messaging, browser automation, analytics, GitHub connector writes, or another
 external tool, return NEEDS_CONTEXT.
+
+In the final response, include `thread_disposition`. Use
+`parent_may_close_thread` unless the parent explicitly needs this same thread
+for the same-patch fix loop.
 """
 
 # Add one [mcp_servers."<server_id_from_your_config>"] block for each MCP
@@ -203,7 +207,14 @@ NEEDS_CONTEXT and let the orchestrator handle it.
 
 You are not alone in the codebase. Do not revert edits made by others. Adapt to
 current files, run only assigned local checks, and return changed files,
-commands run, and concerns.
+commands run, concerns, and `thread_disposition`.
+
+Set `thread_disposition` to:
+- `parent_may_close_thread` when the assigned task is done, blocked, or handed
+  back to the parent;
+- `keep_open_for_same_patch_fix_loop` only when you expect the parent to send a
+  follow-up fix request for this same patch and write set;
+- `blocked_needs_context` when external context or live access is required.
 """
 
 # Add one [mcp_servers."<server_id_from_your_config>"] block for each MCP
@@ -259,6 +270,24 @@ Avoid these default roles:
 
 Those surfaces stay with the orchestrator unless a project explicitly designs a
 separate audited, read-only, sandboxed role for one narrow operation.
+
+## Thread Lifecycle
+
+Project-local worker threads are disposable execution contexts, not durable
+memory stores. The durable memory is the repo: PRDs, plans, handoffs, commits,
+tests, and review notes.
+
+Keep an implementation worker open only while it is in the same-patch
+review/fix loop. Close it after the patch is accepted, rejected, taken over by
+the orchestrator, blocked, or moved to a new write set.
+
+Reviewer and explorer threads are one-shot by default. Close them immediately
+after recording their findings, and use a fresh reviewer for re-review after
+fixes.
+
+Every project worker and specialist should end with a `thread_disposition`
+field so the orchestrator does not have to remember whether the thread can be
+closed.
 
 ## What To Put In The Project Worker
 

--- a/templates/project/.codex/agents/project_code_worker.toml
+++ b/templates/project/.codex/agents/project_code_worker.toml
@@ -21,7 +21,12 @@ NEEDS_CONTEXT and let the orchestrator handle it.
 
 You are not alone in the codebase. Do not revert edits made by others. Adapt to
 current files, run only assigned local checks, and return changed files,
-commands run, and concerns.
+commands run, concerns, and `thread_disposition`.
+
+Use `thread_disposition = "parent_may_close_thread"` unless the parent should
+keep this same thread open for the same-patch fix loop. Use
+`thread_disposition = "blocked_needs_context"` when external context or live
+access is required.
 """
 
 # Before relying on no-MCP isolation, add one disabled MCP block per MCP server

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -89,6 +89,14 @@ Default concurrency:
 - at most three open subagent threads total;
 - close completed or errored agents immediately after recording their result.
 
+Thread lifecycle:
+
+- implementation workers may stay open only through the same-patch review/fix loop;
+- close an implementation worker after its patch is accepted, rejected, blocked, taken over locally, or moved to a different write set;
+- reviewer, explorer, and docs-specialist threads are one-shot by default; close them after recording the result;
+- use a fresh reviewer for re-review after fixes;
+- every subagent final response should include `thread_disposition`: `parent_may_close_thread`, `keep_open_for_same_patch_fix_loop`, or `blocked_needs_context`.
+
 While worker agents are active:
 
 - avoid parallel shell/tool calls;

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Default to one worker agent at a time. Run at most two worker agents in parallel
 
 When custom agents are available, use the project-local no-MCP worker from `.codex/agents/` for implementation work. Rich-MCP orchestrator sessions may use external tools, but coding workers should not inherit MCP servers; use the global `code_worker_no_mcp` only as fallback.
 
-Keep at most three subagent threads open, close completed threads promptly, and avoid parallel shell/tool calls while workers are active. If the executor reports `Too many open files`, stream disconnects, or failed process creation, stop spawning agents and recover sequentially with `git status --short --branch` and `git diff --check` before continuing.
+Keep at most three subagent threads open, close completed threads promptly, and avoid parallel shell/tool calls while workers are active. Implementation workers may remain open only for the same-patch review/fix loop; reviewers are one-shot and should be replaced by a fresh reviewer for re-review after fixes. Every subagent final response should include `thread_disposition` so the orchestrator can close threads deliberately. If the executor reports `Too many open files`, stream disconnects, or failed process creation, stop spawning agents and recover sequentially with `git status --short --branch` and `git diff --check` before continuing.
 
 ## MCP/App connector policy
 

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -43,7 +43,7 @@ This repository follows the agent engineering kernel.
 - serious closeouts record `Kernel Impact`
 - PR closes the leaf issue only
 - agents should read or invoke relevant Superpowers skills before acting: `using-superpowers` / `brainstorming` for new behavior, `writing-plans` for multi-step work, `test-driven-development` for implementation, `systematic-debugging` for bugs, and `verification-before-completion` before success claims
-- orchestrated agentic coding keeps one accountable orchestrator, defaults to one worker agent, permits at most two parallel workers only with disjoint write sets, uses targeted reviewer agents, and stops spawning agents after executor/resource failures such as `Too many open files`
+- orchestrated agentic coding keeps one accountable orchestrator, defaults to one worker agent, permits at most two parallel workers only with disjoint write sets, uses targeted one-shot reviewer agents, keeps implementation workers open only for the same-patch review/fix loop, requires `thread_disposition`, and stops spawning agents after executor/resource failures such as `Too many open files`
 - rich-MCP orchestrators use project-local no-MCP coding workers from `.codex/agents/` so implementation workers do not inherit external MCP servers
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
 - shell-safe `gh` is the fallback when MCP/App connector tooling is missing, stale, or blocked

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -101,6 +101,15 @@ class RepoKernelCanonTests(unittest.TestCase):
             "avoid_parallel_shell_or_tool_wrappers_while_worker_agents_are_active",
             agentic_policy["tool_load_rules"],
         )
+        self.assertIn(
+            "implementation_worker_thread_is_kept_open_only_for_same_patch_review_fix_loop",
+            agentic_policy["thread_lifecycle_rules"],
+        )
+        self.assertIn(
+            "reviewer_explorer_and_docs_specialist_threads_are_single_use_by_default",
+            agentic_policy["thread_lifecycle_rules"],
+        )
+        self.assertIn("parent_may_close_thread", agentic_policy["thread_disposition_values"])
         self.assertIn("too_many_open_files", agentic_policy["recovery_triggers"])
         self.assertIn(
             "do_not_edit_runtime_code_or_claim_verification_until_git_status_and_git_diff_check_can_run",
@@ -129,6 +138,10 @@ class RepoKernelCanonTests(unittest.TestCase):
         )
         self.assertIn(
             "keep_worker_config_small_and_use_project_docs_skills_runbooks_handoffs_for_domain_knowledge",
+            worker_policy["worker_content_rules"],
+        )
+        self.assertIn(
+            "require_thread_disposition_in_worker_final_response",
             worker_policy["worker_content_rules"],
         )
         self.assertIn(
@@ -504,6 +517,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertNotIn("/Users/", worker_content)
         self.assertIn("NEEDS_CONTEXT", worker["developer_instructions"])
         self.assertIn("repo-local skills, runbooks, README files, and handoffs", worker["developer_instructions"])
+        self.assertIn("thread_disposition", worker["developer_instructions"])
 
     def test_kernel_docs_and_templates_mention_kernel_adoption_task(self) -> None:
         for rel in (


### PR DESCRIPTION
Closes #44

## Summary

- add exact thread lifecycle rules for implementation workers, reviewers, explorers, and docs specialists
- require thread_disposition in subagent final responses
- update kernel references, templates, YAML canon, skill entrypoint, changelog, and tests

## Verification

- python3.11 - <<PY ... YAML/TOML parse
- python3.11 -m unittest tests/test_repo_kernel_canon.py
- python3.11 -m unittest discover -s tests -v
- git diff --check
