### PR TITLE
docs: define Claude Code subagent canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added agentic coding orchestration canon: orchestrator/worker/reviewer roles, subagent concurrency limits, prompt write-set contract, review boundaries, and recovery protocol for executor resource failures.
 - Added project-local no-MCP worker canon and templates so rich-MCP orchestrators can dispatch lightweight implementation workers with global fallback behavior.
+- Added Claude Code subagent adapter canon for one-shot read-only review, strict empty MCP startup, OAuth-safe CLI defaults, and no silent fallback to another agent family when Claude Code was explicitly requested.
 - Added explicit subagent thread lifecycle rules: same-patch worker fix loops, one-shot reviewers, fresh re-reviewers, and required `thread_disposition` in final responses.
 - Added Superpowers-compatible process-skill orchestration to the kernel canon and project templates.
 - Added MCP/App connector tooling policy, including GitHub App permission checks, different identities for connector versus local `gh`, and shell-safe fallback behavior.

--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -136,16 +136,22 @@ agentic_coding_orchestration_policy:
   worker_selection_order:
     - project_local_code_worker_for_project_implementation_and_docs_changes
     - global_code_worker_no_mcp_only_when_project_local_worker_is_unavailable_or_task_is_project_agnostic
+    - claude_code_readonly_adapter_only_when_explicitly_requested_or_project_authorized
     - built_in_generic_worker_only_when_no_no_mcp_worker_exists_or_orchestrator_session_is_lightweight
   project_local_worker_files:
     - .codex/config.toml
     - .codex/agents/<project_slug>_code_worker.toml
+    - .claude/agents/<project_slug>_readonly_reviewer.md_optional
+    - scripts/claude-code-readonly-subagent.sh_optional_helper
   worker_mcp_rules:
     - rich_mcp_orchestrators_may_use_mcp_for_research_connectors_browser_analytics_messaging_or_other_external_operations
     - coding_workers_disable_project_or_operator_mcp_server_ids_in_agent_config
+    - claude_code_one_shot_workers_pass_explicit_empty_mcp_config_and_strict_mcp_config
     - kernel_does_not_prescribe_a_fixed_mcp_server_id_list
     - do_not_rely_on_task_prompt_to_disable_mcp_startup
     - worker_that_needs_external_context_returns_needs_context_for_orchestrator
+    - when_user_explicitly_requests_claude_code_do_not_silently_fallback_to_gpt_or_codex_on_claude_failure
+    - diagnose_claude_code_cli_auth_mcp_tool_or_process_failure_before_retry_or_fallback
   concurrency_defaults:
     max_worker_agents_default: 1
     max_worker_agents_parallel: 2
@@ -219,9 +225,13 @@ project_local_worker_policy:
     project_worker: .codex/agents/<project_slug>_code_worker.toml
     optional_project_reviewer: .codex/agents/<project_slug>_reviewer.toml
     optional_project_docs_worker: .codex/agents/<project_slug>_docs_worker.toml
+    optional_claude_code_readonly_reviewer: .claude/agents/<project_slug>_readonly_reviewer.md
+    optional_claude_code_readonly_wrapper: scripts/claude-code-readonly-subagent.sh
     project_canon: AGENTS.md
   selection_rules:
     - orchestrator_explicitly_selects_project_local_worker_for_project_implementation_and_docs_changes
+    - claude_code_adapter_default_role_is_one_shot_readonly_review_or_design_review
+    - claude_code_adapter_is_not_default_implementation_worker_without_project_prd
     - add_project_local_specialist_roles_only_after_repeated_need_proves_a_clear_boundary
     - project_local_reviewer_is_read_only_for_diff_spec_safety_privacy_runtime_and_test_gap_review
     - project_local_docs_worker_writes_docs_only_from_orchestrator_evidence_and_project_docs
@@ -235,6 +245,9 @@ project_local_worker_policy:
     - dispatch_prompt_names_task_specific_docs_skills_runbooks_or_handoffs_to_read
     - disable_current_project_or_operator_mcp_server_ids_in_worker_config
     - disabled_mcp_entries_still_include_command_or_url_transport_to_avoid_invalid_transport_loader_errors
+    - claude_code_oauth_backed_local_runs_do_not_use_bare_by_default
+    - claude_code_bare_mode_requires_explicit_api_key_or_api_key_helper_verification
+    - claude_code_empty_mcp_config_is_mcpServers_empty_object_not_empty_json_object
     - do_not_copy_project_specific_mcp_ids_or_local_paths_from_another_project
     - keep_task_specific_write_sets_and_verification_commands_in_the_dispatch_prompt
   worker_mcp_inventory_rules:
@@ -245,6 +258,7 @@ project_local_worker_policy:
     - leave_project_specific_mcp_names_in_project_config_not_the_universal_kernel
   verification_rules:
     - parse_global_and_project_worker_toml_before_use
+    - run_claude_auth_status_or_project_claude_wrapper_smoke_before_using_claude_code_adapter
     - start_a_fresh_session_after_agent_config_changes
     - verify_worker_availability_before_spawning_workers
     - record_platform_gaps_when_custom_agent_selection_is_unavailable
@@ -598,6 +612,19 @@ model_adapter_policy:
     - verbosity
     - planning_mechanics
     - platform_specific_skills_plugins_or_commands
+  claude_code_subagent_adapter:
+    default_role: readonly_one_shot_reviewer_or_design_reviewer
+    default_allowed_tools:
+      - Read
+      - Grep
+      - Glob
+    default_mcp_config: '{"mcpServers":{}}'
+    strict_mcp_config_required: true
+    no_session_persistence_default: true
+    bare_mode_default: false
+    default_max_budget_usd: 2
+    no_silent_fallback_when_explicitly_requested: true
+    default_wrapper: scripts/claude-code-readonly-subagent.sh
   primary_target: GPT-5.4/Codex
   secondary_target: Claude Code
   hard_rule:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is the standalone source-of-truth for:
 - a reusable Codex skill
 - agentic coding orchestration with explicit worker/reviewer limits and recovery rules
 - project-local no-MCP coding workers with global fallback worker guidance
+- Claude Code subagent adapter rules for one-shot read-only review with strict no-MCP startup
 - repo-managed GitHub metadata and community-health baseline
 - kernel sync review for promoting proven project learnings back into the universal kernel
 - optional GitHub Projects layer only when the repository actually needs shared planning views beyond issue-first execution
@@ -117,6 +118,7 @@ Agentic coding orchestration canon:
 - rich-MCP orchestrators dispatch project-local no-MCP coding workers when custom agents are available
 - project-local workers are preferred over the global `code_worker_no_mcp` fallback for implementation inside a repo
 - project-local no-MCP configs disable the MCP server ids that exist in that project/operator environment; the kernel does not prescribe a fixed MCP list
+- Claude Code may be used as a one-shot read-only reviewer/design reviewer with `claude -p`, explicit empty MCP config, strict MCP enforcement, and read-only `Read,Grep,Glob` tools; if the operator explicitly asks for Claude Code and it fails, diagnose Claude Code instead of silently switching to another agent family
 - default to one worker agent at a time
 - run at most two worker agents concurrently, and only when write sets and runtime resources are disjoint
 - run reviewer agents selectively for security, DB, runtime/deploy, privacy/logging, production integration, or broad multi-file changes
@@ -233,6 +235,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - decision record for environment promotion canon
 - [docs/agentic-coding-orchestration-prd-2026-04-27.md](docs/agentic-coding-orchestration-prd-2026-04-27.md)
   - decision record for orchestrated agentic coding limits and recovery protocol
+- [docs/claude-code-subagent-canon-prd-2026-05-02.md](docs/claude-code-subagent-canon-prd-2026-05-02.md)
+  - decision record for using Claude Code as a bounded no-MCP subagent adapter
 
 ## Bootstrap a project
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,6 +43,8 @@ The agentic coding orchestration rule is explicit:
 - one orchestrator remains accountable for scope, verification, docs, commits, and runtime checks
 - rich-MCP orchestrators should dispatch project-local no-MCP coding/review/docs workers when custom agents are available
 - project-local workers are preferred over the global no-MCP fallback for project implementation
+- Claude Code can be used as a one-shot read-only reviewer/design reviewer adapter with explicit empty MCP config, strict MCP enforcement, and read-only `Read,Grep,Glob` tools
+- when the operator explicitly asks for Claude Code and it fails, diagnose Claude Code CLI/auth/MCP/tool/process setup instead of silently switching to GPT/Codex
 - default to one worker agent at a time
 - use at most two parallel worker agents only with disjoint write sets and healthy local executor state
 - close completed subagent threads promptly
@@ -72,6 +74,7 @@ The environment-promotion rule is explicit:
 - establishing PRD-first execution
 - establishing Superpowers-compatible process-skill orchestration
 - establishing orchestrator / worker / reviewer agentic coding limits and recovery protocol
+- establishing Claude Code as a bounded no-MCP subagent adapter
 - establishing MCP/App connector tooling boundaries and GitHub App permission checks
 - establishing GitHub `Epic / Task / Bug` workflow
 - establishing automatic deduplicated GitHub bug intake

--- a/docs/claude-code-subagent-canon-prd-2026-05-02.md
+++ b/docs/claude-code-subagent-canon-prd-2026-05-02.md
@@ -1,0 +1,183 @@
+# PRD: Claude Code Subagent Adapter Canon
+
+Date: 2026-05-02
+
+Status: accepted
+
+Last updated: 2026-05-02
+
+## Purpose
+
+Define how projects that use this kernel may run Claude Code as a bounded
+subagent without forking the engineering process or inheriting the
+orchestrator's MCP/App connector surface.
+
+The kernel already defines orchestrator, worker, reviewer, no-MCP worker, and
+thread-lifecycle rules. This slice adds the Claude Code adapter details:
+startup, auth checks, MCP isolation, allowed tools, one-shot lifecycle,
+failure handling, and the no-silent-fallback rule.
+
+## Classification
+
+This is an `external_contract_slice` because it documents Claude Code CLI,
+settings, MCP, SDK, and subagent behavior.
+
+## Problem
+
+Projects can run a rich orchestrator with many MCP/App connector tools, then
+ask for "Claude Code as a subagent." Without a durable adapter rule, agents can
+make two unsafe mistakes:
+
+- launch Claude Code with inherited MCP or broad tools, multiplying processes
+  and external surfaces;
+- if Claude Code fails, silently switch to a GPT/Codex worker instead of
+  diagnosing the Claude Code setup the operator explicitly requested.
+
+One real failure mode observed on 2026-05-02: `claude -p --bare ...` failed
+with `Not logged in` on an OAuth-backed local installation. The same local
+Claude Code installation worked when run without `--bare` and with explicit
+empty MCP config plus strict MCP enforcement.
+
+## Goals
+
+- Keep one model-agnostic engineering workflow.
+- Treat Claude Code as an adapter under the same orchestrator/worker/reviewer
+  canon.
+- Make the default Claude Code worker one-shot and read-only.
+- Disable MCP by configuration/CLI flags, not only by prompt text.
+- Preserve OAuth-backed local Claude Code sessions by avoiding `--bare` unless
+  API-key or `apiKeyHelper` mode is explicitly configured.
+- Require root-cause diagnosis when the user explicitly requests Claude Code
+  and Claude Code fails.
+
+## Non-Goals
+
+- Do not make Claude Code the default implementation worker for every project.
+- Do not require every bootstrapped project to install or authenticate Claude
+  Code.
+- Do not grant Claude Code live services, production, GitHub writes, database
+  writes, or messaging access by default.
+- Do not store Anthropic API keys, Claude account state, or operator identity
+  in repository files.
+
+## External Source Of Truth Matrix
+
+| Contract | Source | Verified fact | Kernel decision |
+| --- | --- | --- | --- |
+| Non-interactive CLI | Anthropic Claude Code CLI reference | `claude -p` / `--print` runs non-interactively; CLI supports `--mcp-config`, `--strict-mcp-config`, `--permission-mode`, `--settings`, and prompt input | Use CLI one-shot mode for worker/reviewer adapter runs |
+| MCP isolation | Anthropic Claude Code CLI and MCP docs | Claude Code accepts MCP config and strict MCP config controls | Pass an explicit empty MCP config and strict MCP flag for no-MCP worker runs |
+| Tool allowlist | Anthropic Claude Code SDK docs | SDK examples constrain agents with `allowed_tools`, including `Read`, `Glob`, and `Grep` | Default read-only Claude worker uses only `Read`, `Grep`, and `Glob` |
+| Project subagents | Anthropic Claude Code subagents docs | Project agents can live under `.claude/agents/` and define tools/model/limits in frontmatter | Projects may add `.claude/agents/<project_slug>_readonly_reviewer.md` as an optional project-local Claude role |
+| Settings and auth surfaces | Anthropic Claude Code settings docs | User/local/project settings and MCP configuration are separate surfaces | Do not store Claude auth secrets in project docs; run an auth health check before relying on Claude Code |
+
+Sources checked with Tavily Search and Extract on 2026-05-02:
+
+- https://docs.anthropic.com/en/docs/claude-code/cli-reference
+- https://docs.anthropic.com/en/docs/claude-code/settings
+- https://docs.anthropic.com/en/docs/claude-code/mcp
+- https://docs.anthropic.com/en/docs/claude-code/sdk
+- https://docs.anthropic.com/en/docs/claude-code/sub-agents
+
+## Decision
+
+Claude Code is a model adapter, not a second engineering process.
+
+Default approved use:
+
+- one-shot read-only reviewer or design-review worker;
+- local repository context only;
+- no MCP;
+- no Bash/Edit/Write/MultiEdit by default;
+- orchestrator performs external research and live-service operations, then
+  passes evidence into the Claude Code prompt.
+
+The canonical OAuth-backed local invocation shape is:
+
+```bash
+claude -p \
+  --no-session-persistence \
+  --mcp-config '{"mcpServers":{}}' \
+  --strict-mcp-config \
+  --tools 'Read,Grep,Glob' \
+  --permission-mode dontAsk \
+  --max-budget-usd "${CLAUDE_WORKER_MAX_BUDGET_USD:-2}" \
+  "$prompt"
+```
+
+Rules:
+
+- Do not add `--bare` to the default command. Use `--bare` only when the
+  project/operator explicitly configured API-key or `apiKeyHelper` mode and
+  verified it with a smoke test.
+- The empty MCP config is `{"mcpServers":{}}`, not `{}`.
+- If Claude Code fails auth, tool, MCP, permission, or process startup checks,
+  stop and diagnose. Do not silently substitute a GPT/Codex worker when the
+  operator explicitly asked for Claude Code.
+- If fallback is needed, ask for explicit operator approval and record the
+  adapter gap.
+- Claude Code process exit ends the one-shot worker. There is no persistent
+  thread to keep open.
+- If Claude Code hangs, terminate that process, record partial evidence, and
+  recover sequentially before retrying.
+
+The default local worker budget guardrail is USD 2 per run:
+
+```text
+CLAUDE_WORKER_MAX_BUDGET_USD:-2
+```
+
+Projects may lower or raise that environment variable in local/operator
+configuration, but should not hard-code billing credentials or account details
+in the repository.
+
+## Project Template Decision
+
+Bootstrapped projects receive an optional helper:
+
+```text
+scripts/claude-code-readonly-subagent.sh
+```
+
+The helper:
+
+- checks that `claude` exists;
+- runs `claude auth status` as a health check;
+- uses non-interactive `-p`;
+- passes an explicit empty MCP config;
+- enforces strict MCP config;
+- allows only `Read,Grep,Glob`;
+- requires a prompt argument;
+- does not store or print secrets.
+
+Projects can later add an optional Claude project subagent definition:
+
+```text
+.claude/agents/<project_slug>_readonly_reviewer.md
+```
+
+That file is project-specific and should not be generated blindly by the
+universal bootstrap unless the project has decided to support Claude Code.
+
+## Verification Plan
+
+- Update machine-readable kernel policy.
+- Update long-form references.
+- Update project bootstrap templates.
+- Add the helper script to the bootstrap file set.
+- Add tests proving the bootstrap includes the helper and canon text.
+- Run unit tests and diff whitespace checks.
+
+## Rollback
+
+- Remove the Claude Code adapter sections from kernel references and templates.
+- Remove `scripts/claude-code-readonly-subagent.sh` from project templates.
+- Leave the generic no-MCP worker canon unchanged.
+
+## Kernel Impact
+
+`promote_to_kernel`
+
+This rule is reusable across repositories and prevents a repeated operator
+failure mode: treating "Claude Code as subagent" as either an unconstrained
+external process or a request that can be silently replaced by a different
+agent family.

--- a/references/AGENTIC_CODING_ORCHESTRATION.md
+++ b/references/AGENTIC_CODING_ORCHESTRATION.md
@@ -26,6 +26,18 @@ Checked on 2026-04-27:
   https://developers.openai.com/codex/subagents
   https://developers.openai.com/codex/mcp
 
+Checked on 2026-05-02:
+
+- Claude Code CLI supports non-interactive print mode, MCP config, and strict
+  MCP config:
+  https://docs.anthropic.com/en/docs/claude-code/cli-reference
+- Claude Code SDK examples support constrained `allowed_tools`, including
+  read-only `Read`, `Glob`, and `Grep`:
+  https://docs.anthropic.com/en/docs/claude-code/sdk
+- Claude Code project subagents can live in `.claude/agents/` and define tool
+  and runtime limits in frontmatter:
+  https://docs.anthropic.com/en/docs/claude-code/sub-agents
+
 ## Roles
 
 The orchestrator is the single accountable engineering owner for the slice.
@@ -65,6 +77,14 @@ the project's or operator's MCP server ids to `enabled = false`. The universal
 kernel does not prescribe a fixed MCP list; each project copies its own server
 ids and valid transport fields from the local MCP configuration. See
 `references/PROJECT_LOCAL_WORKERS.md` for the full setup pattern.
+
+Claude Code may be used as an external subagent adapter under the same role
+model. The default Claude Code adapter role is one-shot, read-only review or
+design review, not implementation. It should be launched with explicit empty
+MCP config, strict MCP enforcement, and a small read-only tool allowlist. If
+the operator explicitly requested Claude Code and the launch fails, diagnose
+the Claude Code CLI/auth/MCP/tool configuration before using another agent
+family.
 
 Reviewer and specialist agents are optional and targeted. Start a project with
 one project-local code worker, then add roles only when repeated work creates a
@@ -158,10 +178,25 @@ Worker MCP policy:
   worker can follow prompt instructions;
 - disable the current project/operator MCP server ids at the worker config
   layer for coding workers;
+- for Claude Code one-shot workers, pass an explicit empty MCP config and
+  strict MCP flag at launch time;
 - if a coding worker needs external research or a live service, it returns
   `NEEDS_CONTEXT` and the orchestrator performs that step;
 - keep rich-MCP sessions for orchestrators and read-only research agents, not
   implementation workers.
+
+Claude Code one-shot lifecycle:
+
+- run non-interactively with `claude -p`;
+- avoid `--bare` for OAuth-backed local Claude Code sessions unless API-key or
+  `apiKeyHelper` mode was explicitly configured and smoke-tested;
+- use `--mcp-config '{"mcpServers":{}}'` and `--strict-mcp-config`;
+- use `--tools 'Read,Grep,Glob'` for read-only review;
+- treat process exit as the end of the subagent thread;
+- if it hangs, terminate the process, record partial evidence, and recover
+  sequentially before retrying;
+- do not silently replace it with another worker family when the user asked
+  for Claude Code.
 
 Before spawning a worker:
 

--- a/references/MODEL_ADAPTERS.md
+++ b/references/MODEL_ADAPTERS.md
@@ -23,6 +23,38 @@ The engineering kernel is shared. The model adapter is thin.
 - which MCP server or App connector surfaces are available
 - whether a thin behavior-only overlay is materialized in a tool-specific surface
 
+## Claude Code as a subagent adapter
+
+Claude Code can be used as an external subagent, but it remains an adapter
+under the shared orchestrator/worker/reviewer workflow. It is not a separate
+engineering process and not a reason to bypass PRD, write-set, review,
+verification, or rollback rules.
+
+Default approved shape:
+
+- one-shot read-only reviewer or design-review worker;
+- local repository context only;
+- no inherited MCP/App connector surface;
+- read-only tools only, normally `Read`, `Grep`, and `Glob`;
+- orchestrator supplies external research evidence, live-system facts, and the
+  exact question to review.
+
+When the operator explicitly asks for Claude Code, do not silently substitute a
+GPT/Codex worker if Claude Code fails. Diagnose Claude Code first:
+
+- is the CLI installed;
+- is auth healthy for the intended auth mode;
+- is MCP disabled with strict config;
+- are tool permissions scoped correctly;
+- did the process exit, hang, or fail before starting.
+
+Fallback to another agent family only after explicit operator approval and a
+recorded adapter gap.
+
+For OAuth-backed local Claude Code installs, do not add `--bare` to the default
+worker command. `--bare` is reserved for explicitly verified API-key or
+`apiKeyHelper` configurations.
+
 ## Behavioral overlay rule
 
 An optional behavior-only layer may exist across tool-specific surfaces such as:

--- a/references/PROJECT_LOCAL_WORKERS.md
+++ b/references/PROJECT_LOCAL_WORKERS.md
@@ -19,6 +19,21 @@ Checked on 2026-04-27:
   allowlist behavior:
   https://developers.openai.com/codex/config-reference
 
+Checked on 2026-05-02:
+
+- Claude Code CLI supports non-interactive print mode, `--mcp-config`, and
+  `--strict-mcp-config`:
+  https://docs.anthropic.com/en/docs/claude-code/cli-reference
+- Claude Code settings and MCP configuration are separate local/project
+  surfaces and must not be treated as repository secrets:
+  https://docs.anthropic.com/en/docs/claude-code/settings
+  https://docs.anthropic.com/en/docs/claude-code/mcp
+- Claude Code SDK examples support constrained read-only tool allowlists:
+  https://docs.anthropic.com/en/docs/claude-code/sdk
+- Claude Code project subagents can be described under `.claude/agents/` with
+  frontmatter-defined tools and limits:
+  https://docs.anthropic.com/en/docs/claude-code/sub-agents
+
 ## Pattern
 
 Use four role layers:
@@ -111,6 +126,18 @@ Optional project-local specialist workers:
 ```text
 <repo>/.codex/agents/<project_slug>_reviewer.toml
 <repo>/.codex/agents/<project_slug>_docs_worker.toml
+```
+
+Optional Claude Code project subagent:
+
+```text
+<repo>/.claude/agents/<project_slug>_readonly_reviewer.md
+```
+
+Optional Claude Code one-shot wrapper:
+
+```text
+<repo>/scripts/claude-code-readonly-subagent.sh
 ```
 
 Project canon:
@@ -271,6 +298,99 @@ Avoid these default roles:
 Those surfaces stay with the orchestrator unless a project explicitly designs a
 separate audited, read-only, sandboxed role for one narrow operation.
 
+## Claude Code Read-Only Subagent Adapter
+
+Claude Code is an external model adapter under this same worker canon. It does
+not create a second engineering workflow.
+
+Use Claude Code by default only for:
+
+- read-only review of an existing diff;
+- design or PRD review from repository files and evidence supplied by the
+  orchestrator;
+- small, bounded comparison of project docs, plans, or code paths.
+
+Do not use the default Claude Code adapter for:
+
+- implementation edits;
+- live service access;
+- production/staging operations;
+- database writes or migrations;
+- GitHub issue/PR writes;
+- messaging sends;
+- customer data export;
+- external research unless a separate research role is explicitly designed.
+
+The canonical one-shot command for an OAuth-backed local Claude Code install
+is:
+
+```bash
+claude -p \
+  --no-session-persistence \
+  --mcp-config '{"mcpServers":{}}' \
+  --strict-mcp-config \
+  --tools 'Read,Grep,Glob' \
+  --permission-mode dontAsk \
+  --max-budget-usd "${CLAUDE_WORKER_MAX_BUDGET_USD:-2}" \
+  "$prompt"
+```
+
+Use the project helper when available:
+
+```bash
+scripts/claude-code-readonly-subagent.sh "$prompt"
+```
+
+Important details:
+
+- the empty MCP config is `{"mcpServers":{}}`, not `{}`;
+- do not use `--bare` by default for OAuth-backed local sessions;
+- use `--bare` only when API-key or `apiKeyHelper` mode is explicitly
+  configured and smoke-tested;
+- keep `--tools` read-only unless a project PRD authorizes a stronger role;
+- keep the default `$2` budget cap unless the operator sets
+  `CLAUDE_WORKER_MAX_BUDGET_USD` for that environment;
+- do not put Anthropic API keys, auth state, or operator account details in the
+  repository;
+- run `claude auth status` or the project wrapper health check before relying
+  on the worker.
+
+If the user explicitly requests Claude Code and Claude Code fails, stop and
+diagnose:
+
+- CLI missing;
+- auth unhealthy;
+- wrong auth mode, such as `--bare` with an OAuth-only local install;
+- invalid MCP config;
+- tool permission mismatch;
+- process hang or resource exhaustion.
+
+Do not silently switch to GPT/Codex or another agent family. Fallback requires
+explicit operator approval and a recorded adapter gap.
+
+An optional project-local Claude subagent file can document the role for Claude
+Code users:
+
+```markdown
+---
+name: <project_slug>_readonly_reviewer
+description: Read-only project reviewer. No MCP, no edits, no live systems.
+tools: Read, Grep, Glob
+---
+
+You are a read-only reviewer for this repository.
+
+Follow AGENTS.md and the active PRD supplied by the orchestrator. Do not edit
+files, run live checks, deploy, print secrets, or access customer data. If the
+task needs external research or live context, return NEEDS_CONTEXT.
+
+Return findings, open questions, verification gaps, and:
+thread_disposition: parent_may_close_thread
+```
+
+Project subagent files are optional because not every project uses Claude
+Code. The universal bootstrap includes only the shell wrapper and canon text.
+
 ## Thread Lifecycle
 
 Project-local worker threads are disposable execution contexts, not durable
@@ -284,6 +404,11 @@ the orchestrator, blocked, or moved to a new write set.
 Reviewer and explorer threads are one-shot by default. Close them immediately
 after recording their findings, and use a fresh reviewer for re-review after
 fixes.
+
+Claude Code `claude -p` adapter runs are process-based one-shot workers. When
+the process exits, the worker is closed. If a Claude Code process hangs, kill
+that process, record the partial result, and recover sequentially before
+retrying.
 
 Every project worker and specialist should end with a `thread_disposition`
 field so the orchestrator does not have to remember whether the thread can be

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -70,14 +70,17 @@ Project-local worker files:
 ```text
 .codex/config.toml
 .codex/agents/project_code_worker.toml
+scripts/claude-code-readonly-subagent.sh
 ```
 
 Selection rules:
 
 - use `project_code_worker` for scoped implementation changes and small docs updates in this repository
+- use Claude Code only as an explicitly requested or project-authorized one-shot read-only reviewer/design reviewer unless an active PRD defines a stronger role
 - add project-local specialist roles only after repeated need proves a clear boundary, for example `project_reviewer` for read-only diff/spec review or `project_docs_worker` for docs-only closeout writing
 - use the global `code_worker_no_mcp` only as a fallback when the project-local worker is unavailable or the task is truly project-agnostic
 - do not use built-in generic workers from a rich-MCP orchestrator session when a project-local no-MCP worker exists
+- do not silently substitute GPT/Codex or another worker family when the operator explicitly asks for Claude Code and Claude Code fails; diagnose Claude Code CLI/auth/MCP/tool/process setup first
 - if a worker needs external research or live service access, it returns `NEEDS_CONTEXT` and the orchestrator performs that step
 - keep research, live runtime, deployment, provider consoles, customer data cleanup, and production operations with the orchestrator unless this project explicitly designs a narrow audited role for one of those surfaces
 
@@ -103,6 +106,15 @@ While worker agents are active:
 - avoid broad repeated file scans unless needed;
 - do not busy-poll agents;
 - do not launch background services unless the task requires them.
+
+Claude Code adapter rules:
+
+- default Claude Code role is one-shot read-only review/design review;
+- launch through `scripts/claude-code-readonly-subagent.sh` when available;
+- use non-interactive `claude -p`, `--no-session-persistence`, `--mcp-config '{"mcpServers":{}}'`, `--strict-mcp-config`, and read-only tools `Read,Grep,Glob`;
+- do not use `--bare` for OAuth-backed local Claude Code sessions unless API-key or `apiKeyHelper` mode was explicitly configured and smoke-tested;
+- do not grant Claude Code implementation, live systems, GitHub writes, database writes, messaging, secrets, or customer data access without an active PRD;
+- process exit closes the Claude Code worker; if it hangs, terminate it, record partial evidence, and recover sequentially.
 
 If the executor reports resource failures such as `Too many open files`, stream disconnects, or failed process creation:
 
@@ -259,4 +271,5 @@ If this repository also uses a thin behavior-only layer such as `CLAUDE.md`, a C
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
 - `scripts/check_kernel_upstream.py`
+- `scripts/claude-code-readonly-subagent.sh`
 - active PRD / decision doc in `docs/`

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -24,6 +24,8 @@ Default to one worker agent at a time. Run at most two worker agents in parallel
 
 When custom agents are available, use the project-local no-MCP worker from `.codex/agents/` for implementation work. Rich-MCP orchestrator sessions may use external tools, but coding workers should not inherit MCP servers; use the global `code_worker_no_mcp` only as fallback.
 
+Claude Code may be used as a one-shot read-only reviewer/design reviewer through `scripts/claude-code-readonly-subagent.sh`. The default Claude Code adapter uses `claude -p`, no session persistence, explicit empty MCP config, strict MCP enforcement, and read-only `Read,Grep,Glob` tools. Do not use `--bare` for OAuth-backed local Claude Code sessions unless API-key or `apiKeyHelper` mode has been explicitly configured and smoke-tested. If the operator explicitly asks for Claude Code and it fails, diagnose Claude Code CLI/auth/MCP/tool/process setup before requesting approval to use any fallback agent family.
+
 Keep at most three subagent threads open, close completed threads promptly, and avoid parallel shell/tool calls while workers are active. Implementation workers may remain open only for the same-patch review/fix loop; reviewers are one-shot and should be replaced by a fresh reviewer for re-review after fixes. Every subagent final response should include `thread_disposition` so the orchestrator can close threads deliberately. If the executor reports `Too many open files`, stream disconnects, or failed process creation, stop spawning agents and recover sequentially with `git status --short --branch` and `git diff --check` before continuing.
 
 ## MCP/App connector policy

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -45,6 +45,7 @@ This repository follows the agent engineering kernel.
 - agents should read or invoke relevant Superpowers skills before acting: `using-superpowers` / `brainstorming` for new behavior, `writing-plans` for multi-step work, `test-driven-development` for implementation, `systematic-debugging` for bugs, and `verification-before-completion` before success claims
 - orchestrated agentic coding keeps one accountable orchestrator, defaults to one worker agent, permits at most two parallel workers only with disjoint write sets, uses targeted one-shot reviewer agents, keeps implementation workers open only for the same-patch review/fix loop, requires `thread_disposition`, and stops spawning agents after executor/resource failures such as `Too many open files`
 - rich-MCP orchestrators use project-local no-MCP coding workers from `.codex/agents/` so implementation workers do not inherit external MCP servers
+- Claude Code, when used as a subagent, defaults to a one-shot read-only reviewer/design reviewer launched with strict empty MCP config and `Read,Grep,Glob` tools through `scripts/claude-code-readonly-subagent.sh`; if explicitly requested and it fails, diagnose Claude Code instead of silently switching agent families
 - `gh issue create` and `gh pr create` should use `--body-file` or a single-quoted heredoc-generated file, not inline markdown bodies
 - shell-safe `gh` is the fallback when MCP/App connector tooling is missing, stale, or blocked
 - for GitHub sub-issues, prefer `scripts/link_github_sub_issue.py`; if you call REST directly, `sub_issue_id` means child issue database id, not `#issue_number`
@@ -65,4 +66,5 @@ This repository follows the agent engineering kernel.
 - `.github/labels.yml`
 - `scripts/sync_github_labels.py`
 - `scripts/check_kernel_upstream.py`
+- `scripts/claude-code-readonly-subagent.sh`
 - active PRD in `docs/`

--- a/templates/project/scripts/claude-code-readonly-subagent.sh
+++ b/templates/project/scripts/claude-code-readonly-subagent.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/claude-code-readonly-subagent.sh "review prompt"
+
+Runs Claude Code as a one-shot read-only subagent:
+  - no session persistence
+  - empty MCP config with strict MCP enforcement
+  - read-only tools only: Read,Grep,Glob
+  - default max budget: ${CLAUDE_WORKER_MAX_BUDGET_USD:-2} USD
+
+Do not use this wrapper for implementation edits, live systems, production
+operations, secrets, customer data export, messaging sends, or GitHub writes.
+
+Exit codes:
+  64  invalid usage
+  78  Claude Code auth/config is unhealthy
+  127 claude command not found
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 64
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude_not_found: install and authenticate Claude Code before using this adapter" >&2
+  exit 127
+fi
+
+if ! claude auth status >/dev/null 2>&1; then
+  echo "claude_auth_unhealthy: run 'claude auth login' or configure the approved API-key helper path" >&2
+  exit 78
+fi
+
+prompt=$1
+
+exec claude -p \
+  --no-session-persistence \
+  --mcp-config '{"mcpServers":{}}' \
+  --strict-mcp-config \
+  --tools 'Read,Grep,Glob' \
+  --permission-mode dontAsk \
+  --max-budget-usd "${CLAUDE_WORKER_MAX_BUDGET_USD:-2}" \
+  "$prompt"

--- a/tests/test_bootstrap_project_kernel.py
+++ b/tests/test_bootstrap_project_kernel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -29,6 +30,7 @@ class BootstrapProjectKernelTests(unittest.TestCase):
         self.assertIn(".github/pull_request_template.md", files)
         self.assertIn("scripts/sync_github_labels.py", files)
         self.assertIn("scripts/check_kernel_upstream.py", files)
+        self.assertIn("scripts/claude-code-readonly-subagent.sh", files)
         self.assertIn(".kernel/upstream.json", files)
         self.assertIn("docs/PRD_TEMPLATE.md", files)
 
@@ -56,6 +58,8 @@ class BootstrapProjectKernelTests(unittest.TestCase):
             self.assertTrue((target / ".github" / "labels.yml").exists())
             self.assertTrue((target / "scripts" / "sync_github_labels.py").exists())
             self.assertTrue((target / "scripts" / "check_kernel_upstream.py").exists())
+            self.assertTrue((target / "scripts" / "claude-code-readonly-subagent.sh").exists())
+            self.assertTrue(os.access(target / "scripts" / "claude-code-readonly-subagent.sh", os.X_OK))
             self.assertTrue((target / ".kernel" / "upstream.json").exists())
             self.assertIn("fingerprint", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("raw logs", (target / "AGENTS.md").read_text(encoding="utf-8"))
@@ -65,6 +69,8 @@ class BootstrapProjectKernelTests(unittest.TestCase):
             self.assertIn("kernel_upstream_check", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("staging", (target / "AGENTS.md").read_text(encoding="utf-8"))
             self.assertIn("mutating automated tests must not run against production", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("Claude Code adapter rules", (target / "AGENTS.md").read_text(encoding="utf-8"))
+            self.assertIn("--strict-mcp-config", (target / "scripts" / "claude-code-readonly-subagent.sh").read_text(encoding="utf-8"))
             self.assertIn("Kernel Impact", (target / "docs" / "PRD_TEMPLATE.md").read_text(encoding="utf-8"))
             self.assertIn("production backup or restore point", (target / "docs" / "PRD_TEMPLATE.md").read_text(encoding="utf-8"))
             self.assertIn("paid GitHub-hosted Actions", (target / "CONTRIBUTING.md").read_text(encoding="utf-8"))

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -90,7 +90,15 @@ class RepoKernelCanonTests(unittest.TestCase):
             agentic_policy["worker_selection_order"],
         )
         self.assertIn(
+            "claude_code_readonly_adapter_only_when_explicitly_requested_or_project_authorized",
+            agentic_policy["worker_selection_order"],
+        )
+        self.assertIn(
             "do_not_rely_on_task_prompt_to_disable_mcp_startup",
+            agentic_policy["worker_mcp_rules"],
+        )
+        self.assertIn(
+            "claude_code_one_shot_workers_pass_explicit_empty_mcp_config_and_strict_mcp_config",
             agentic_policy["worker_mcp_rules"],
         )
         self.assertIn(
@@ -128,6 +136,14 @@ class RepoKernelCanonTests(unittest.TestCase):
             worker_policy["preferred_files"]["optional_project_docs_worker"],
             ".codex/agents/<project_slug>_docs_worker.toml",
         )
+        self.assertEqual(
+            worker_policy["preferred_files"]["optional_claude_code_readonly_wrapper"],
+            "scripts/claude-code-readonly-subagent.sh",
+        )
+        self.assertIn(
+            "claude_code_adapter_default_role_is_one_shot_readonly_review_or_design_review",
+            worker_policy["selection_rules"],
+        )
         self.assertIn(
             "each_project_owns_its_mcp_disable_list",
             worker_policy["worker_mcp_inventory_rules"],
@@ -149,9 +165,21 @@ class RepoKernelCanonTests(unittest.TestCase):
             worker_policy["worker_content_rules"],
         )
         self.assertIn(
+            "claude_code_oauth_backed_local_runs_do_not_use_bare_by_default",
+            worker_policy["worker_content_rules"],
+        )
+        self.assertIn(
             "do_not_copy_project_specific_mcp_ids_or_local_paths_from_another_project",
             worker_policy["worker_content_rules"],
         )
+        model_policy = payload["model_adapter_policy"]
+        claude_adapter = model_policy["claude_code_subagent_adapter"]
+        self.assertEqual(claude_adapter["default_role"], "readonly_one_shot_reviewer_or_design_reviewer")
+        self.assertEqual(claude_adapter["default_allowed_tools"], ["Read", "Grep", "Glob"])
+        self.assertEqual(claude_adapter["default_mcp_config"], '{"mcpServers":{}}')
+        self.assertTrue(claude_adapter["strict_mcp_config_required"])
+        self.assertFalse(claude_adapter["bare_mode_default"])
+        self.assertEqual(claude_adapter["default_max_budget_usd"], 2)
         research_policy = payload["research_policy"]
         self.assertIn("slice_classification", research_policy)
         self.assertEqual(
@@ -237,6 +265,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "templates/project/scripts/check_kernel_upstream.py",
             "templates/project/scripts/link_github_sub_issue.py",
             "templates/project/scripts/sync_github_labels.py",
+            "templates/project/scripts/claude-code-readonly-subagent.sh",
             "templates/project/docs/PRD_TEMPLATE.md",
         ):
             self.assertTrue((ROOT / rel).exists(), rel)
@@ -501,6 +530,26 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("Too many open files", content, rel)
             self.assertIn("git status --short --branch", content, rel)
             self.assertIn("parallel", content.lower(), rel)
+
+    def test_kernel_docs_and_templates_mention_claude_code_adapter(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/MODEL_ADAPTERS.md",
+            "references/AGENTIC_CODING_ORCHESTRATION.md",
+            "references/PROJECT_LOCAL_WORKERS.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "docs/claude-code-subagent-canon-prd-2026-05-02.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("Claude Code", content, rel)
+            self.assertIn("MCP", content, rel)
+            self.assertIn("Read", content, rel)
+            self.assertIn("Grep", content, rel)
+            self.assertIn("Glob", content, rel)
+            self.assertIn("fallback", content.lower(), rel)
 
     def test_project_local_worker_templates_parse_and_use_project_mcp_inventory(self) -> None:
         config = tomllib.loads((ROOT / "templates/project/.codex/config.toml").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What changed

- Added a PRD for using Claude Code as a bounded subagent adapter.
- Extended the machine-readable kernel, model adapter policy, agentic orchestration policy, and project-local worker policy.
- Added a bootstrapped helper: `scripts/claude-code-readonly-subagent.sh`.
- Updated project templates and tests so downstream repos inherit the no-MCP Claude Code rule.

## Why

When an operator explicitly asks for Claude Code, agents must not silently switch to GPT/Codex if Claude Code fails. The kernel now requires diagnosing Claude Code CLI/auth/MCP/tool/process setup first, and the default adapter is one-shot read-only review with explicit empty MCP config.

## Verification

- `.venv/bin/python -m unittest discover -s tests`
- `bash -n templates/project/scripts/claude-code-readonly-subagent.sh`
- `git diff --check`
- `templates/project/scripts/claude-code-readonly-subagent.sh 'Reply exactly: CLAUDE_WORKER_OK'`
- Claude Code read-only reviewer run via the new wrapper; no blocking findings.

## Notes

This is a docs/canon/bootstrap-template change. No production project code or live systems are touched.
