### PR TITLE
docs: add risk-based required CI canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -362,6 +362,10 @@ execution_surface_policy:
     - detect_local_prerequisites_before_work_starts
     - if_repo_defines_a_local_bootstrap_path_run_it_or_repair_it
     - use_github_actions_only_when_local_or_self_hosted_execution_is_not_the_right_surface
+    - do_not_use_workflow_level_path_filters_or_commit_message_skips_for_required_workflows
+    - use_lightweight_classifier_jobs_before_expensive_required_jobs
+    - risk_gate_expensive_required_jobs_with_job_level_if_conditions
+    - force_full_required_ci_for_main_release_manual_scheduled_dependency_workflow_and_explicit_full_ci_override
 
 environment_promotion_policy:
   default_environment_classes:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Execution-surface canon:
 - GitHub coordinates repository workflow: issues, PRs, check status, schedules, and deploy triggers
 - owned compute executes routine work by default: local machine first, then self-hosted runners for recurring checks
 - self-hosted runners are preferred over paid GitHub-hosted Actions when the repository already has them or can reasonably provide them
+- required GitHub workflows stay triggered; risk-based classifier jobs and job-level `if` gates reduce expensive jobs without leaving required checks `Pending`
+- `full-ci` or an equivalent explicit override forces the full matrix, as do main, release, scheduled, manual, dependency, and workflow changes
 - paid GitHub-hosted runners, dependency cache uploads, and long-lived artifact storage are explicit exceptions for private repositories, not defaults
 - GitHub Actions remain for repo-native automation, schedules, deploys, and hosted checks that actually belong there
 - production-bound work should document local, disposable verify, staging, and production boundaries before launch hardening

--- a/docs/risk-based-required-ci-prd-2026-05-03.md
+++ b/docs/risk-based-required-ci-prd-2026-05-03.md
@@ -1,0 +1,39 @@
+# Risk-Based Required CI PRD
+
+Date: 2026-05-03
+Issue: #55
+
+## Source Learning
+
+This kernel update promotes a verified downstream learning from `telethone` #350 / PR #351.
+
+The downstream problem was practical: a single self-hosted runner kept small PRs waiting for the full backend, frontend, and supply-chain matrix. The unsafe shortcut would be workflow-level path filters or commit-message skips on required workflows.
+
+## External Contract
+
+Fresh GitHub documentation checked on 2026-05-03:
+
+- GitHub documents that workflow-level path filtering, branch filtering, or skip commit messages can leave required checks in `Pending` when the workflow is skipped before jobs are created.
+- GitHub documents that skipped jobs report `Success` and do not block required checks.
+- GitHub workflow syntax supports job-level `jobs.<job_id>.if` conditions.
+
+## Decision
+
+For required CI workflows:
+
+- keep required workflows triggered;
+- add a lightweight classifier job;
+- use job-level `if` conditions to skip expensive irrelevant jobs;
+- treat skipped jobs as acceptable only when the job was created and skipped by the documented classifier;
+- force full required CI for main, release/deploy, scheduled, manual, dependency, workflow, and explicit `full-ci` override changes.
+
+## Acceptance
+
+- `ENGINEERING_KERNEL.yaml` records the rule.
+- `references/EXECUTION_SURFACES.md` explains the pattern and why workflow-level skips are not the default optimization path.
+- Project templates carry the rule into downstream `README.md`, `AGENTS.md`, and `CONTRIBUTING.md`.
+- Deterministic tests prevent regression.
+
+## Kernel Impact
+
+This is the universal kernel change. Consumer repositories may adopt it through their normal `kernel_upstream_check` / `kernel_adoption_task` flow.

--- a/references/EXECUTION_SURFACES.md
+++ b/references/EXECUTION_SURFACES.md
@@ -49,6 +49,25 @@ Use GitHub Actions when the value is specifically repository-native automation:
 - hosted verification that must execute inside GitHub
 - branch/merge policy checks that belong to the repository platform
 
+## Risk-Based Required CI
+
+For required checks, do not use workflow-level `paths`, `paths-ignore`, or
+commit-message skip instructions as the normal optimization path. If the whole
+workflow is skipped before jobs are created, GitHub can leave required checks in
+`Pending`.
+
+Keep required workflows triggered, then reduce runner load inside the workflow:
+
+- run a lightweight classifier job first
+- gate expensive jobs with job-level `if` conditions
+- let irrelevant jobs become `skipped` required checks instead of missing checks
+- run the full required CI matrix for `main`, release/deploy, scheduled,
+  manual, dependency, workflow, and explicit `full-ci` override changes
+
+This is risk-based CI: the repository still gets required check visibility, but
+small frontend-only, backend-only, docs-only, or canon-only PRs do not consume
+unrelated self-hosted runner time.
+
 ## Environment Promotion
 
 Execution surfaces answer where work runs. Environment promotion answers how code,
@@ -93,6 +112,8 @@ Project-local canon should state:
 - whether the project has self-hosted runners
 - the self-hosted runner label(s) for recurring repository checks
 - which workflows must remain in GitHub Actions
+- which required workflows use risk-based classifier jobs and job-level gates
+- the explicit `full-ci` override label or equivalent manual full-check path
 - the environment promotion path from local to verify to staging to production
 - the production-safe migration/deploy command and backup or restore-point path
 - that agents should not route routine dev/test work to paid hosted Actions by

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -167,6 +167,8 @@ Project-local rules may make these limits stricter, especially for live producti
 - document the project self-hosted runner label(s) before enabling recurring GitHub checks
 - check local prerequisites before work starts
 - if the repo defines a local bootstrap path, use or repair it before escalating elsewhere
+- keep required workflows triggered and use risk-based classifier jobs plus job-level `if` gates for expensive jobs instead of workflow-level skips that can leave required checks `Pending`
+- use `full-ci` or an equivalent explicit override for the full matrix; main, release, scheduled, manual, dependency, and workflow changes also run full CI
 - use GitHub Actions for repository-native automation, schedules, deploys, and hosted verification that genuinely belongs there
 - do not enable paid GitHub-hosted runners, dependency cache uploads, or long-lived artifact storage without an explicit PRD/decision note
 

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -55,6 +55,8 @@ Keep at most three subagent threads open, close completed threads promptly, and 
 - GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute should execute routine work by default
 - if the repository already has self-hosted runners or can reasonably provide them, prefer them over paid GitHub-hosted Actions for recurring work
 - document the self-hosted runner label(s) before enabling recurring GitHub checks
+- keep required workflows triggered and use risk-based classifier jobs plus job-level `if` gates for expensive jobs instead of workflow-level skips that can leave required checks `Pending`
+- use `full-ci` or an equivalent explicit override for the full matrix; main, release, scheduled, manual, dependency, and workflow changes also run full CI
 - check or bootstrap local prerequisites before assuming CI is the right place to run the work
 - keep GitHub Actions for repository-native automation, schedules, deploys, and hosted checks that genuinely need the platform
 - do not enable paid GitHub-hosted runners, dependency cache uploads, or long-lived artifact storage without an explicit PRD/decision note

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -24,6 +24,8 @@ This repository follows the agent engineering kernel.
 - GitHub coordinates issues, PRs, check status, schedules, and deploy triggers; owned compute should execute routine work by default
 - if the project has self-hosted runners or can reasonably provide them, prefer them over paid GitHub-hosted Actions for recurring work
 - document self-hosted runner labels before enabling recurring GitHub checks
+- required workflows should stay triggered; use risk-based classifier jobs and job-level `if` gates for expensive jobs instead of workflow-level skips that can leave required checks `Pending`
+- `full-ci` or an equivalent explicit override forces the full matrix, as do main, release, scheduled, manual, dependency, and workflow changes
 - GitHub Actions are for repository-native automation, schedules, deploys, and hosted checks that genuinely belong there
 - paid GitHub-hosted runners, dependency cache uploads, and long-lived artifact storage require an explicit PRD/decision note
 - production-bound work documents `local`, disposable `verify`, `staging`, and `production` boundaries before launch hardening

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -253,6 +253,21 @@ class RepoKernelCanonTests(unittest.TestCase):
             environment_promotion_policy["rules"],
         )
 
+    def test_machine_readable_kernel_includes_risk_based_required_ci(self) -> None:
+        payload = yaml.safe_load((ROOT / "ENGINEERING_KERNEL.yaml").read_text(encoding="utf-8"))
+        execution_policy = payload["execution_surface_policy"]
+        rules = execution_policy["rules"]
+        self.assertIn(
+            "do_not_use_workflow_level_path_filters_or_commit_message_skips_for_required_workflows",
+            rules,
+        )
+        self.assertIn("use_lightweight_classifier_jobs_before_expensive_required_jobs", rules)
+        self.assertIn("risk_gate_expensive_required_jobs_with_job_level_if_conditions", rules)
+        self.assertIn(
+            "force_full_required_ci_for_main_release_manual_scheduled_dependency_workflow_and_explicit_full_ci_override",
+            rules,
+        )
+
     def test_kernel_readme_and_templates_document_pre_change_baseline_rule(self) -> None:
         readme_text = (ROOT / "README.md").read_text(encoding="utf-8")
         self.assertIn("baseline verification when an existing contract already exists", readme_text)
@@ -368,6 +383,22 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("owned compute", content, rel)
             self.assertIn("paid GitHub-hosted", content, rel)
             self.assertIn("dependency cache", content, rel)
+
+    def test_kernel_docs_and_templates_explain_risk_based_required_ci(self) -> None:
+        for rel in (
+            "README.md",
+            "references/EXECUTION_SURFACES.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            normalized = content.lower()
+            self.assertIn("risk-based", normalized, rel)
+            self.assertIn("job-level", normalized, rel)
+            self.assertIn("required check", normalized, rel)
+            self.assertIn("pending", normalized, rel)
+            self.assertIn("full-ci", normalized, rel)
 
     def test_kernel_docs_and_templates_mention_environment_promotion(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary

- Promotes the telethone #350 / PR #351 live learning into the universal execution-surface canon.
- Documents risk-based required CI: keep required workflows triggered, then gate expensive jobs with classifier outputs and job-level `if`.
- Updates machine-readable kernel rules and project templates so downstream repos can bootstrap the pattern.

## External Evidence

- GitHub docs say workflow-level path/branch/commit-message skips can leave required checks `Pending`.
- GitHub docs say skipped jobs report `Success` and do not block required checks.
- GitHub workflow syntax supports `jobs.<job_id>.if` job-level conditions.

## Verification

- RED: new kernel canon tests failed before the rule/docs/templates existed.
- `uv run --with PyYAML python -m unittest tests.test_repo_kernel_canon.RepoKernelCanonTests.test_machine_readable_kernel_includes_risk_based_required_ci tests.test_repo_kernel_canon.RepoKernelCanonTests.test_kernel_docs_and_templates_explain_risk_based_required_ci`
- `uv run --with PyYAML python -m unittest discover -s tests`
- `git diff --check`

Closes #55.
