### PR TITLE
Add cutover entitlement parity canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -12,6 +12,7 @@ layers:
   minimal_core:
     - project_local_canon
     - prd_first_execution
+    - cutover_entitlement_parity_policy
     - agent_skill_orchestration_policy
     - agentic_coding_orchestration_policy
     - project_local_worker_policy
@@ -70,6 +71,33 @@ prd_first_execution:
     - refactor_slices_prefer_before_and_after_equivalence_checks
     - docs_only_canon_only_or_greenfield_slices_may_skip_pre_change_baseline_if_no_existing_contract_exists
     - docs_and_prd_are_part_of_the_slice
+
+cutover_entitlement_parity_policy:
+  applies_to:
+    - new_shell_or_navigation_model
+    - admin_information_architecture_cutover
+    - major_ui_default_cutover
+  source_of_truth_rules:
+    - identify_existing_entitlement_or_capability_source_of_truth_before_cutover
+    - new_default_ui_must_consume_the_same_entitlement_source_or_record_explicit_replacement_decision
+    - server_authorization_remains_the_security_boundary_but_client_surface_filtering_must_match_expected_roles
+  required_role_matrix:
+    - unauthenticated
+    - personal_user
+    - workspace_owner_or_admin
+    - workspace_member
+    - enterprise_or_account_admin
+    - platform_admin
+  required_surfaces:
+    - desktop_navigation
+    - mobile_navigation
+    - command_or_search_palette
+    - topbar_or_page_chrome
+    - direct_route_restricted_state
+  default_cutover_rules:
+    - do_not_make_new_shell_navigation_admin_ia_or_major_ui_default_until_role_matrix_parity_is_green
+    - record_cutover_entitlement_role_matrix_evidence_in_active_prd_or_closeout
+    - treat_beautiful_ui_that_blurs_entitlements_as_a_regression_not_a_design_tradeoff
 
 agent_skill_orchestration_policy:
   preferred_skill_pack: Superpowers

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository is the standalone source-of-truth for:
 - a canonical `kernel_adoption_task` so downstream repos handle kernel drift deterministically
 - optional kernel fleet sweep so one operator machine can review many consumer repos at once
 - environment promotion canon for local, disposable verify, staging, and production boundaries
+- cutover entitlement parity for new shell/navigation/admin UI defaults
 
 The goal is simple: a new agent in a new repository should not need the workflow re-explained in chat.
 
@@ -94,6 +95,14 @@ Verification canon:
 - production secrets and production database URLs must not be used in local verification
 - mutating automated tests must not run against production data or production provider identities
 - post-change verification before publish remains mandatory
+
+Cutover entitlement parity canon:
+
+- before a new shell, navigation model, admin information architecture, or major UI becomes default, identify the existing entitlement source of truth
+- the new default UI must consume the same entitlement source or record an explicit replacement decision
+- role-matrix evidence must cover unauthenticated, personal, workspace owner/admin, workspace member, enterprise/admin, and platform admin paths
+- desktop navigation, mobile navigation, command/search palette, topbar/page chrome, and direct restricted routes must be checked before default cutover
+- server authorization remains the security boundary, but client surfaces that blur role visibility are regressions, not design polish
 
 Environment-promotion canon:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,12 @@ The environment-promotion rule is explicit:
 - production secrets and production database URLs must not be used in local config or local tests
 - mutating automated tests must not run against production
 
+The cutover entitlement parity rule is explicit:
+
+- a new shell, navigation model, admin information architecture, or major UI cannot become default until role-matrix evidence proves the same entitlement source of truth is respected
+- the role-matrix covers unauthenticated, personal, workspace owner/admin, workspace member, enterprise/admin, and platform admin surfaces
+- desktop navigation, mobile navigation, command/search palette, topbar/page chrome, and direct restricted routes are checked before default cutover
+
 ## Use this skill for
 
 - creating a reusable engineering kernel for future projects
@@ -82,6 +88,7 @@ The environment-promotion rule is explicit:
 - establishing Tavily Search-first research behavior, with Tavily Research reserved for justified expensive deep-sweeps
 - establishing local-first execution and prerequisite bootstrap
 - establishing environment promotion and production safety rules
+- establishing cutover entitlement parity before a new shell/navigation/admin UI becomes default
 - establishing kernel sync review and kernel impact discipline
 - establishing kernel upstream awareness and downstream adoption checks
 - establishing the canonical `kernel_adoption_task` work item for downstream kernel updates

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -44,6 +44,8 @@ The bootstrapped canon should also make explicit:
 - that production secrets and production database URLs must not be used in local config or local tests
 - that mutating automated tests must not run against production
 - that production-safe migration/deploy command, backup/restore-point path, smoke checks, and rollback are project-local canon
+- that a new shell, navigation model, admin information architecture, or major UI cannot become default until cutover entitlement role-matrix evidence proves it uses the same entitlement source of truth
+- that default cutover role-matrix evidence covers unauthenticated, personal, workspace owner/admin, workspace member, enterprise/admin, platform admin, desktop/mobile navigation, command/search palette, topbar/page chrome, and direct restricted routes
 - that each serious slice begins with `kernel_upstream_check`
 - that each serious slice ends with `kernel_sync_review`
 - that active PRDs and closeouts carry a `Kernel Impact` decision

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -186,6 +186,14 @@ Project-local rules may make these limits stricter, especially for live producti
 - project canon must document backup or restore-point path, staging smoke checks, production smoke checks, and rollback
 - production data may move down to staging only through documented backup/restore and sanitization; local or staging data must not move up to production
 
+## Cutover entitlement parity canon
+
+- a new shell, navigation model, admin information architecture, or major UI cannot become default until it proves entitlement parity with the existing source of truth
+- record cutover role-matrix evidence in the active PRD or closeout before default rollout
+- the default role-matrix covers unauthenticated, personal user, workspace owner/admin, workspace member, enterprise/admin, and platform admin
+- the default surface matrix covers desktop navigation, mobile navigation, command/search palette, topbar/page chrome, and direct restricted routes
+- server authorization remains the security boundary, but UI surfaces that expose the wrong role experience are regressions
+
 ## Kernel sync canon
 
 - every serious slice begins with `kernel_upstream_check`

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -72,6 +72,29 @@ Keep at most three subagent threads open, close completed threads promptly, and 
 - Do not run mutating automated tests against production.
 - Document the production-safe migration/deploy command, backup or restore-point path, smoke checks, and rollback before production use.
 
+## Cutover entitlement parity
+
+Before making a new shell, navigation model, admin information architecture, or major UI the default, record cutover entitlement role-matrix evidence in the PRD or closeout.
+
+Required role-matrix coverage:
+
+- unauthenticated
+- personal user
+- workspace owner/admin
+- workspace member
+- enterprise/admin
+- platform admin
+
+Required surface coverage:
+
+- desktop navigation
+- mobile navigation
+- command/search palette
+- topbar/page chrome
+- direct restricted routes
+
+The new default UI must use the same entitlement source of truth as the existing product, unless the PRD records an explicit replacement decision. Server authorization remains mandatory, but it is not enough by itself; client surfaces must not blur roles.
+
 ## Start from the correct issue
 
 Use:

--- a/templates/project/README.md
+++ b/templates/project/README.md
@@ -32,6 +32,8 @@ This repository follows the agent engineering kernel.
 - production secrets and production database URLs must not be used in local verification
 - mutating automated tests must not run against production
 - production-safe migration/deploy command, backup or restore-point path, smoke checks, and rollback must be project-local canon
+- new shell, navigation, admin information architecture, or major UI cutover cannot become default until entitlement role-matrix evidence proves the same source of truth is respected
+- default cutover role-matrix evidence covers unauthenticated, personal, workspace owner/admin, workspace member, enterprise/admin, platform admin, desktop/mobile navigation, command/search palette, topbar/page chrome, and direct restricted routes
 - serious slices begin with `kernel_upstream_check`
 - the project pins its upstream kernel commit in `.kernel/upstream.json`
 - if drift exists, open or update a `kernel_adoption_task`

--- a/templates/project/docs/PRD_TEMPLATE.md
+++ b/templates/project/docs/PRD_TEMPLATE.md
@@ -72,6 +72,27 @@ Record near slice start.
 
 Phased plan with validation and rollback.
 
+## Cutover Entitlement Role-Matrix
+
+Required when the slice makes a new shell, navigation model, admin information architecture, or major UI the default.
+
+- default cutover in scope: `yes | no`
+- entitlement source of truth:
+- replacement decision if not using the existing entitlement source: `n/a | describe`
+- role-matrix evidence:
+  - unauthenticated:
+  - personal user:
+  - workspace owner/admin:
+  - workspace member:
+  - enterprise/admin:
+  - platform admin:
+- surface evidence:
+  - desktop navigation:
+  - mobile navigation:
+  - command/search palette:
+  - topbar/page chrome:
+  - direct restricted routes:
+
 For production-bound work, record:
 
 - local verification path;

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -63,12 +63,21 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("kernel_adoption_task_policy", payload)
         self.assertIn("kernel_fleet_sweep_policy", payload)
         self.assertIn("kernel_sync_policy", payload)
+        self.assertIn("cutover_entitlement_parity_policy", payload)
         prd_first = payload["prd_first_execution"]
         self.assertIn("baseline_verification", prd_first["order"])
         self.assertIn("post_change_verification", prd_first["order"])
         self.assertIn(
             "capture_smallest_relevant_baseline_verification_before_edits_when_existing_contract_exists",
             prd_first["rules"],
+        )
+        cutover_policy = payload["cutover_entitlement_parity_policy"]
+        self.assertIn("workspace_member", cutover_policy["required_role_matrix"])
+        self.assertIn("platform_admin", cutover_policy["required_role_matrix"])
+        self.assertIn("command_or_search_palette", cutover_policy["required_surfaces"])
+        self.assertIn(
+            "do_not_make_new_shell_navigation_admin_ia_or_major_ui_default_until_role_matrix_parity_is_green",
+            cutover_policy["default_cutover_rules"],
         )
         skill_policy = payload["agent_skill_orchestration_policy"]
         self.assertEqual(skill_policy["preferred_skill_pack"], "Superpowers")
@@ -421,6 +430,23 @@ class RepoKernelCanonTests(unittest.TestCase):
             if rel != "references/GITHUB_DELIVERY.md":
                 self.assertIn("production secrets", content.lower(), rel)
                 self.assertIn("mutating", content.lower(), rel)
+
+    def test_kernel_docs_and_templates_mention_cutover_entitlement_parity(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/BOOTSTRAP.md",
+            "templates/project/README.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+            "templates/project/docs/PRD_TEMPLATE.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            normalized = content.lower()
+            self.assertIn("cutover", normalized, rel)
+            self.assertIn("entitlement", normalized, rel)
+            self.assertIn("role-matrix", normalized, rel)
+            self.assertIn("default", normalized, rel)
 
     def test_kernel_workflow_uses_owned_compute_runner(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add machine-readable cutover entitlement parity policy to the kernel
- document the rule in README, skill entrypoint, bootstrap guidance, and project templates
- add a PRD template section for default cutover role-matrix evidence
- add deterministic tests that guard the new canon and template coverage

## Verification
- `.venv/bin/python -m unittest tests.test_repo_kernel_canon.RepoKernelCanonTests.test_machine_readable_kernel_parses tests.test_repo_kernel_canon.RepoKernelCanonTests.test_kernel_docs_and_templates_mention_cutover_entitlement_parity`
- `.venv/bin/python -m unittest discover -s tests`
- `git diff --check`

Closes #58
