### PR TITLE
Serialize git ref operations in kernel canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -204,6 +204,8 @@ agentic_coding_orchestration_policy:
   tool_load_rules:
     - avoid_parallel_shell_or_tool_wrappers_while_worker_agents_are_active
     - prefer_sequential_shell_commands_while_worker_agents_are_active
+    - serialize_git_ref_index_and_worktree_mutating_commands_per_repository
+    - do_not_run_git_fetch_pull_switch_checkout_merge_rebase_branch_delete_or_push_in_parallel_for_the_same_repository
     - avoid_broad_repeated_file_scans_unless_needed
     - do_not_busy_poll_agents
     - close_completed_or_abandoned_agent_threads_immediately_after_recording_result
@@ -227,6 +229,7 @@ agentic_coding_orchestration_policy:
     - stop_parallel_shell_and_tool_calls
     - close_completed_or_errored_agent_threads
     - recover_with_minimal_sequential_commands
+    - after_git_ref_lock_race_recover_with_sequential_git_status_fetch_pull_ff_only_and_diff_check
     - do_not_edit_runtime_code_or_claim_verification_until_git_status_and_git_diff_check_can_run
   integration_rules:
     - verify_changed_files_stay_within_allowed_write_set
@@ -577,6 +580,9 @@ github_delivery_flow:
     - prefer_mcp_or_app_connector_for_structured_github_issue_pr_and_metadata_operations_when_available_and_authorized
     - local_gh_auth_and_github_app_connector_auth_are_different_identities_with_separate_permissions
     - if_github_connector_returns_resource_not_accessible_by_integration_check_installed_github_app_repository_access_and_permissions
+    - serialize_git_ref_index_and_worktree_mutating_commands_per_repository
+    - do_not_run_git_fetch_pull_switch_checkout_merge_rebase_branch_delete_or_push_in_parallel_for_the_same_repository
+    - after_git_ref_lock_race_recover_with_sequential_git_status_fetch_pull_ff_only_and_diff_check
     - never_embed_markdown_with_backticks_in_inline_double_quoted_gh_body_arguments
     - single_quoted_heredoc_is_an_acceptable_fallback_only_when_it_writes_the_body_file_first
     - when_linking_sub_issues_from_cli_prefer_the_kernel_helper_or_graphql_addSubIssue_after_resolving_issue_node_ids

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Agentic coding orchestration canon:
 - keep at most three subagent threads open and close completed threads immediately
 - keep implementation workers open only for the same-patch review/fix loop; treat reviewers as one-shot and require `thread_disposition` in subagent final responses
 - avoid parallel shell/tool calls while worker agents are active
+- serialize git ref/index/worktree-mutating commands per repository; never run `git fetch`, `git pull`, `git switch`, `git checkout`, `git merge`, `git rebase`, `git branch -d/-D`, or `git push` in parallel for the same repo
 - stop spawning agents and recover sequentially after executor/resource failures such as `Too many open files` or stream disconnects
 - resume only after `git status --short --branch` and `git diff --check` can run
 - project-local `AGENTS.md` may impose stricter lower limits

--- a/SKILL.md
+++ b/SKILL.md
@@ -53,6 +53,7 @@ The agentic coding orchestration rule is explicit:
 - treat reviewer/explorer/docs-specialist threads as one-shot and use fresh reviewers for re-review
 - require subagent final responses to include `thread_disposition`
 - avoid parallel shell/tool calls while worker agents are active
+- serialize git ref/index/worktree-mutating commands such as `git fetch`, `git pull`, `git switch`, `git merge`, branch deletion, and `git push` per repository; never run them in parallel for the same repo
 - stop spawning agents and recover sequentially after executor/resource failures such as `Too many open files`
 - resume only after `git status --short --branch` and `git diff --check` can run
 

--- a/docs/git-ref-operation-serialization-prd-2026-05-09.md
+++ b/docs/git-ref-operation-serialization-prd-2026-05-09.md
@@ -1,0 +1,50 @@
+# PRD: Git Ref Operation Serialization Canon
+
+Date: `2026-05-09`
+
+Status: `implemented`
+
+## Problem
+
+Agent orchestrators may parallelize shell commands for speed. That is fine for
+read-only file inspection, but it is unsafe for git commands that mutate or
+refresh repository state. A real downstream slice launched `git fetch` and
+`git pull` concurrently in one repository and hit a lock race on
+`refs/remotes/origin/main`.
+
+## Decision
+
+The kernel now treats git commands that touch refs, the index, or the working
+tree as serialized per repository.
+
+These commands must not be run in parallel for the same repo:
+
+- `git fetch`
+- `git pull`
+- `git switch`
+- `git checkout`
+- `git merge`
+- `git rebase`
+- `git branch -d/-D`
+- `git push`
+
+Read-only commands such as `git status`, `git diff`, `git log`, and `git show`
+may be parallelized only when no ref-mutating git command is running for that
+repo and the answer does not depend on a fresh ref update.
+
+## Recovery
+
+After a ref-lock race:
+
+1. stop parallel git calls for that repository;
+2. run `git status --short --branch`;
+3. run the needed `git fetch`;
+4. run `git pull --ff-only` when the goal is to update the current branch;
+5. run `git diff --check` before claiming the repo is healthy.
+
+## Kernel Impact
+
+`promote_to_kernel`
+
+This is a reusable orchestration rule across all repositories, not a
+project-local Plaud rule.

--- a/references/AGENTIC_CODING_ORCHESTRATION.md
+++ b/references/AGENTIC_CODING_ORCHESTRATION.md
@@ -186,6 +186,15 @@ While any worker agent is active:
 - do not launch background services unless required;
 - do not busy-poll agents.
 
+Regardless of whether worker agents are active, git commands that touch refs,
+the index, or the working tree are serialized per repository. Do not run `git
+fetch`, `git pull`, `git switch`, `git checkout`, `git merge`, `git rebase`,
+`git branch -d/-D`, or `git push` through parallel shell/tool wrappers for the
+same repo. They can race on `.git/refs` lock files or leave the operator with a
+misleading local view. If this happens, stop parallel git calls and recover with
+sequential `git status --short --branch`, the needed `git fetch`, `git pull
+--ff-only` when appropriate, and `git diff --check`.
+
 Worker MCP policy:
 
 - do not rely on the task prompt to disable MCP; MCP startup happens before the

--- a/references/GITHUB_DELIVERY.md
+++ b/references/GITHUB_DELIVERY.md
@@ -17,6 +17,20 @@ Tooling rule:
 - if the App connector returns `Resource not accessible by integration`, check the installed GitHub App repository access and permissions before refreshing the local `gh` token
 - when the connector is unavailable, stale, or missing a needed operation, use the shell-safe `gh` fallback below
 
+Git state serialization rule:
+
+- serialize git commands that touch refs, the index, or the working tree within
+  one repository
+- do not run `git fetch`, `git pull`, `git switch`, `git checkout`, `git
+  merge`, `git rebase`, `git branch -d/-D`, or `git push` through parallel
+  tool wrappers for the same repo
+- read-only commands such as `git diff`, `git status`, `git log`, and `git
+  show` may be parallelized only when they do not depend on a fresh ref update
+  and no ref-mutating git command is running for that repo
+- if a ref lock race occurs, recover sequentially: `git status --short
+  --branch`, then the needed `git fetch`, then `git pull --ff-only` when
+  appropriate, then `git diff --check`
+
 ## Canonical sequence
 
 1. Create or update the PRD
@@ -55,6 +69,8 @@ production deploy, read-safe production smoke checks, and monitoring.
 - when using `gh issue create`, `gh issue edit`, or `gh pr create` from shell, prefer `--body-file` over inline `--body`
 - when MCP or an App connector can do the structured write, prefer it over shelling out, then verify the connector path itself
 - do not treat a working local `gh` token as proof that the GitHub App connector has repository access or write permissions
+- serialize git ref/index/worktree-mutating commands per repository; never run
+  fetch/pull/merge/switch/branch-delete/push in parallel for the same repo
 - never embed markdown with backticks or fenced code blocks in inline double-quoted `gh --body` arguments
 - acceptable fallback is a single-quoted heredoc such as `<<'EOF'` that writes the body file first
 - when linking GitHub sub-issues from the CLI, prefer `scripts/link_github_sub_issue.py` or GraphQL `addSubIssue` after resolving issue node ids

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -136,6 +136,13 @@ If the executor reports resource failures such as `Too many open files`, stream 
 
 Project-local rules may make these limits stricter, especially for live production surfaces.
 
+Git ref/index/worktree operations must be serialized per repository. Do not run
+`git fetch`, `git pull`, `git switch`, `git checkout`, `git merge`, `git
+rebase`, `git branch -d/-D`, or `git push` in parallel for the same repo. If a
+ref lock race occurs, recover with sequential `git status --short --branch`,
+the needed `git fetch`, `git pull --ff-only` when appropriate, and `git diff
+--check`.
+
 ## Research canon
 
 - use Tavily Search first, not Tavily Research first

--- a/templates/project/CONTRIBUTING.md
+++ b/templates/project/CONTRIBUTING.md
@@ -28,6 +28,8 @@ Claude Code may be used as a one-shot read-only reviewer/design reviewer through
 
 Keep at most three subagent threads open, close completed threads promptly, and avoid parallel shell/tool calls while workers are active. Implementation workers may remain open only for the same-patch review/fix loop; reviewers are one-shot and should be replaced by a fresh reviewer for re-review after fixes. Every subagent final response should include `thread_disposition` so the orchestrator can close threads deliberately. If the executor reports `Too many open files`, stream disconnects, or failed process creation, stop spawning agents and recover sequentially with `git status --short --branch` and `git diff --check` before continuing.
 
+Git ref/index/worktree operations are serialized per repository. Do not run `git fetch`, `git pull`, `git switch`, `git checkout`, `git merge`, `git rebase`, `git branch -d/-D`, or `git push` in parallel for the same repo. If a ref lock race occurs, recover sequentially with `git status --short --branch`, the needed `git fetch`, `git pull --ff-only` when appropriate, and `git diff --check`.
+
 ## MCP/App connector policy
 
 - use MCP or App connector tooling for supported structured external-service operations when available and authorized

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -119,6 +119,14 @@ class RepoKernelCanonTests(unittest.TestCase):
             agentic_policy["tool_load_rules"],
         )
         self.assertIn(
+            "serialize_git_ref_index_and_worktree_mutating_commands_per_repository",
+            agentic_policy["tool_load_rules"],
+        )
+        self.assertIn(
+            "do_not_run_git_fetch_pull_switch_checkout_merge_rebase_branch_delete_or_push_in_parallel_for_the_same_repository",
+            agentic_policy["tool_load_rules"],
+        )
+        self.assertIn(
             "implementation_worker_thread_is_kept_open_only_for_same_patch_review_fix_loop",
             agentic_policy["thread_lifecycle_rules"],
         )
@@ -130,6 +138,10 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("too_many_open_files", agentic_policy["recovery_triggers"])
         self.assertIn(
             "do_not_edit_runtime_code_or_claim_verification_until_git_status_and_git_diff_check_can_run",
+            agentic_policy["recovery_rules"],
+        )
+        self.assertIn(
+            "after_git_ref_lock_race_recover_with_sequential_git_status_fetch_pull_ff_only_and_diff_check",
             agentic_policy["recovery_rules"],
         )
         worker_policy = payload["project_local_worker_policy"]
@@ -608,6 +620,22 @@ class RepoKernelCanonTests(unittest.TestCase):
             self.assertIn("Too many open files", content, rel)
             self.assertIn("git status --short --branch", content, rel)
             self.assertIn("parallel", content.lower(), rel)
+
+    def test_kernel_docs_and_templates_serialize_git_ref_operations(self) -> None:
+        for rel in (
+            "README.md",
+            "SKILL.md",
+            "references/GITHUB_DELIVERY.md",
+            "references/AGENTIC_CODING_ORCHESTRATION.md",
+            "templates/project/AGENTS.md",
+            "templates/project/CONTRIBUTING.md",
+        ):
+            content = (ROOT / rel).read_text(encoding="utf-8")
+            self.assertIn("git fetch", content, rel)
+            self.assertIn("git pull", content, rel)
+            self.assertIn("git diff --check", content, rel)
+            self.assertIn("parallel", content.lower(), rel)
+            self.assertIn("same repo", content.lower(), rel)
 
     def test_kernel_docs_and_templates_mention_claude_code_adapter(self) -> None:
         for rel in (


### PR DESCRIPTION
## Summary

- Adds a universal canon rule to serialize git ref/index/worktree-mutating commands per repository.
- Documents the rule in machine-readable kernel YAML, delivery/orchestration references, skill summary, templates, and a decision PRD.
- Adds tests that require the rule to stay visible in docs/templates.

## Verification

- `uv run --with PyYAML --with pytest pytest tests -q` -> 43 passed
- `python3 -m py_compile scripts/*.py`
- `git diff --check`

Closes #60