### PR TITLE
docs: add multi-agent release coordination canon

### DIFF
--- a/ENGINEERING_KERNEL.yaml
+++ b/ENGINEERING_KERNEL.yaml
@@ -15,6 +15,7 @@ layers:
     - cutover_entitlement_parity_policy
     - agent_skill_orchestration_policy
     - agentic_coding_orchestration_policy
+    - multi_agent_release_coordination_policy
     - project_local_worker_policy
     - mcp_tooling_policy
     - research_policy
@@ -245,6 +246,91 @@ agentic_coding_orchestration_policy:
   project_override_rule:
     - project_local_agents_md_may_impose_stricter_limits
     - live_production_projects_should_default_to_one_worker_staging_first_no_worker_deploys_and_orchestrator_only_runtime_verification
+
+multi_agent_release_coordination_policy:
+  core_rule:
+    - main_is_source_of_truth_only_after_verified_integration_pr_is_merged
+    - before_merge_source_of_truth_is_active_release_candidate_branch_sha_pr_deploy_command_runtime_state_and_verification_evidence
+    - do_not_deploy_from_memory_stale_main_dirty_checkout_or_detached_runtime_directory_without_release_candidate_check
+  branch_topologies:
+    single_slice:
+      - main
+      - feature_or_fix_branch
+      - draft_pr
+      - staging
+      - production_when_approved
+      - merge_to_main
+    multiple_agent_slices:
+      - main
+      - independent_agent_branches_or_worktrees
+      - integration_release_branch
+      - draft_pr
+      - staging
+      - production_when_approved
+      - merge_to_main
+  orchestrator_owns:
+    - branch_topology_and_active_prs
+    - allowed_deploy_worktree
+    - deployed_commit_by_environment
+    - runtime_schema_env_verification
+    - pr_comments_or_closeout_evidence
+    - merge_and_branch_cleanup
+  worker_live_runtime_rules:
+    - workers_do_not_deploy_or_mutate_live_databases_or_send_live_messages_by_default
+    - worker_that_lacks_release_context_returns_needs_release_context
+    - second_agent_touching_live_runtime_receives_or_reconstructs_handoff_packet_before_acting
+  handoff_packet_required_fields:
+    - repo_path
+    - source_of_truth_branch
+    - active_worktree
+    - current_release_candidate
+    - exact_commit_sha
+    - issue_or_pr
+    - staging_and_production_urls
+    - deploy_command
+    - backup_requirement
+    - allowed_actions
+    - forbidden_actions
+    - verification_commands
+  runtime_recovery_order:
+    - identify_live_symptom_and_current_health
+    - identify_expected_release_candidate_branch_pr_sha
+    - inspect_runtime_deploy_directory_without_mutating_it
+    - check_project_deploy_runbook_command_and_overlays
+    - package_recovery_change_into_branch_or_integration_branch
+    - verify_locally_or_in_ci_as_appropriate
+    - deploy_staging_from_exact_release_candidate_sha
+    - run_staging_smoke_checks
+    - take_production_backup_before_schema_or_data_changes
+    - deploy_production_from_same_release_candidate_sha_with_documented_command
+    - run_read_safe_production_smoke_checks_and_log_scans
+    - record_evidence_in_pr_or_closeout
+    - merge_verified_pr_to_main
+  deploy_command_contract_fields:
+    - working_directory
+    - branch_or_sha
+    - build_flags
+    - migration_mode
+    - service_or_compose_overlays
+    - env_file_ownership
+    - backup_path
+    - health_endpoints
+    - rollback_path
+  closeout_rules:
+    - pr_evidence_records_commit_deployed_to_staging_and_production_when_applicable
+    - after_merge_fetch_origin_main_and_confirm_merge_commit
+    - delete_remote_release_branch_when_appropriate
+    - keep_or_remove_local_worktrees_intentionally
+    - treat_main_as_source_of_truth_again_after_verified_merge
+  red_flags:
+    - dirty_checkout_with_unexplained_files
+    - detached_checkout_without_recorded_release_candidate_sha
+    - another_agent_has_open_branch_or_pr_already_staged_or_deployed
+    - deploy_command_differs_from_project_runbook
+    - service_or_compose_overlays_are_ambiguous
+    - schema_preview_contains_destructive_or_unrelated_changes
+    - provider_webhook_or_runtime_env_is_inferred_instead_of_inspected
+    - worker_attempts_live_deploy_without_explicit_authority
 
 project_local_worker_policy:
   purpose:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is the standalone source-of-truth for:
 - project bootstrap templates
 - a reusable Codex skill
 - agentic coding orchestration with explicit worker/reviewer limits and recovery rules
+- multi-agent release coordination across branches, worktrees, integration PRs, staging, production, and runtime recovery
 - project-local no-MCP coding workers with global fallback worker guidance
 - Claude Code subagent adapter rules for one-shot read-only review with strict no-MCP startup
 - repo-managed GitHub metadata and community-health baseline
@@ -143,6 +144,16 @@ Agentic coding orchestration canon:
 - resume only after `git status --short --branch` and `git diff --check` can run
 - project-local `AGENTS.md` may impose stricter lower limits
 
+Multi-agent release coordination canon:
+
+- `main` is source of truth only after the verified PR or integration PR is merged
+- before merge, the active release candidate is the source of truth: branch, SHA, PR, deploy command, runtime state, and evidence
+- multiple agent branches that must ship together use an integration branch and draft PR
+- do not deploy production from a stale `main`, dirty checkout, detached runtime directory, or improvised command
+- runtime recovery identifies the active release candidate, deploy overlays/env, schema state, logs, and project runbook before mutating live services
+- production-bound recovery deploys staging first, takes a backup or restore point when schema/data can change, then deploys production with read-safe smoke checks and PR evidence
+- after merge, fetch `origin/main`, confirm the merge commit, clean the release branch intentionally, and treat `main` as source of truth again
+
 MCP tooling canon:
 
 - use MCP or App connector tooling for supported structured external-service operations when available and authorized
@@ -212,6 +223,8 @@ Do not fork the engineering process by model unless a tool constraint truly forc
   - how Superpowers and equivalent process skills should be used without replacing the kernel
 - [references/AGENTIC_CODING_ORCHESTRATION.md](references/AGENTIC_CODING_ORCHESTRATION.md)
   - how an orchestrator should dispatch, limit, review, and recover worker/reviewer agents
+- [references/MULTI_AGENT_RELEASE_COORDINATION.md](references/MULTI_AGENT_RELEASE_COORDINATION.md)
+  - how several agents, branches, worktrees, staging/prod deploys, and runtime recovery are coordinated safely
 - [references/PROJECT_LOCAL_WORKERS.md](references/PROJECT_LOCAL_WORKERS.md)
   - how to create project-local no-MCP coding/review/docs workers, global fallback workers, and worker selection rules
 - [references/MCP_TOOLING.md](references/MCP_TOOLING.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: engineering-kernel
-description: Bootstrap or audit a serious agent-led engineering workflow in any repository. Use when Codex must establish or update project canon, PRD-first execution, GitHub Epic/Task/Bug decomposition, PR verification discipline, reusable bootstrap files, or a model-agnostic workflow that future GPT/Codex and Claude-style agents can reuse without re-explaining the process in chat.
+description: Bootstrap or audit a serious agent-led engineering workflow in any repository. Use when Codex must establish or update project canon, PRD-first execution, GitHub Epic/Task/Bug decomposition, PR verification discipline, multi-agent release coordination, reusable bootstrap files, or a model-agnostic workflow that future GPT/Codex and Claude-style agents can reuse without re-explaining the process in chat.
 ---
 
 # Engineering Kernel
@@ -13,6 +13,7 @@ Read [references/MODEL_ADAPTERS.md](references/MODEL_ADAPTERS.md) when the user 
 Read [references/BEHAVIORAL_OVERLAY.md](references/BEHAVIORAL_OVERLAY.md) when the user asks whether a thin behavior-only guideline layer should exist across `CLAUDE.md`, Cursor rules, or skill/plugin surfaces.
 Read [references/SUPERPOWERS_SKILL_ORCHESTRATION.md](references/SUPERPOWERS_SKILL_ORCHESTRATION.md) when the user asks how Superpowers or another process-skill pack should be used with the kernel.
 Read [references/AGENTIC_CODING_ORCHESTRATION.md](references/AGENTIC_CODING_ORCHESTRATION.md) when the user asks how orchestrator/worker/reviewer agentic coding should be structured, limited, reviewed, and recovered after resource failures.
+Read [references/MULTI_AGENT_RELEASE_COORDINATION.md](references/MULTI_AGENT_RELEASE_COORDINATION.md) when the user asks how multiple agents, branches, worktrees, integration PRs, staging/prod deploys, runtime recovery, or handoffs should be coordinated in one production-bound project.
 Read [references/PROJECT_LOCAL_WORKERS.md](references/PROJECT_LOCAL_WORKERS.md) when the user asks how to create global fallback workers, project-local workers, no-MCP coding/review/docs workers, rich-MCP orchestrators, or worker selection rules.
 Read [references/MCP_TOOLING.md](references/MCP_TOOLING.md) when the user asks how MCP servers, App connector tooling, GitHub App permissions, or local `gh` fallback should be used.
 Read [references/RESEARCH_POLICY.md](references/RESEARCH_POLICY.md) when the user asks how research and evidence collection should work.
@@ -64,6 +65,19 @@ The agentic coding orchestration rule is explicit:
 - stop spawning agents and recover sequentially after executor/resource failures such as `Too many open files`
 - resume only after `git status --short --branch` and `git diff --check` can run
 
+The multi-agent release coordination rule is explicit:
+
+- `main` is source of truth only after the verified integration PR is merged
+- before merge, the source of truth is the active release candidate branch,
+  commit SHA, PR, deploy command, runtime state, and verification evidence
+- never recover production by deploying from a stale, detached, or dirty
+  checkout without first identifying the release candidate
+- multiple agent branches that must ship together go through an integration
+  branch, draft PR, staging verification, production verification when
+  applicable, PR evidence, merge to `main`, and branch cleanup
+- second agents touching live runtime must receive or reconstruct a handoff
+  packet before acting
+
 The MCP tooling rule is explicit:
 
 - prefer MCP or App connector tooling for supported structured external-service operations
@@ -89,6 +103,8 @@ The cutover entitlement parity rule is explicit:
 - establishing PRD-first execution
 - establishing Superpowers-compatible process-skill orchestration
 - establishing orchestrator / worker / reviewer agentic coding limits and recovery protocol
+- establishing multi-agent release coordination across branches, worktrees,
+  integration PRs, staging, production, and runtime recovery
 - establishing Claude Code as a bounded no-MCP subagent adapter
 - establishing MCP/App connector tooling boundaries and GitHub App permission checks
 - establishing GitHub `Epic / Task / Bug` workflow

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
   display_name: "Engineering Kernel"
-  short_description: "Bootstrap PRD-first GitHub and agentic coding canon for a repo"
+  short_description: "Bootstrap PRD-first GitHub, agentic coding, and release canon"

--- a/docs/multi-agent-release-coordination-prd-2026-05-11.md
+++ b/docs/multi-agent-release-coordination-prd-2026-05-11.md
@@ -1,0 +1,66 @@
+# Multi-Agent Release Coordination PRD
+
+Date: 2026-05-11
+
+## Problem
+
+When several agents work on one production-bound repository, a later agent can
+recover or deploy from a stale checkout, dirty runtime directory, or plain
+`main` while another release candidate is already staged or partially deployed.
+That creates runtime regressions, schema drift, and confusion about which branch
+is authoritative.
+
+## Scope
+
+Add a universal kernel rule for coordinating:
+
+- multiple agent branches;
+- integration release branches;
+- clean worktrees;
+- staging and production promotion;
+- runtime recovery;
+- handoff packets between agents;
+- merge and branch cleanup.
+
+## Non-Goals
+
+- Define project-specific deploy commands.
+- Grant workers live production authority.
+- Replace project-local `AGENTS.md` or active PRDs.
+- Force every project to use the same branch names.
+
+## Decision
+
+The kernel now treats `main` as source of truth only after the verified release
+candidate is merged. Before merge, the active release candidate is the source
+of truth: branch, exact SHA, PR, deploy command, runtime state, and verification
+evidence.
+
+Multi-agent production-bound work should use an integration branch when several
+agent branches must ship together. The integration branch is a release
+candidate, gets a draft PR, passes staging, and only then moves to production
+with backup/restore-point evidence when schema or data can change.
+
+Workers do not deploy or mutate live runtime by default. A second agent touching
+live runtime must receive or reconstruct a handoff packet before acting.
+
+## Artifacts
+
+- `references/MULTI_AGENT_RELEASE_COORDINATION.md`
+- `ENGINEERING_KERNEL.yaml`
+- `SKILL.md`
+- `README.md`
+- `references/BOOTSTRAP.md`
+- `templates/project/AGENTS.md`
+- `tests/test_repo_kernel_canon.py`
+
+## Verification Plan
+
+- YAML parses and exposes `multi_agent_release_coordination_policy`.
+- Repo canon test confirms the new reference exists and key policy values are
+  machine-readable.
+- Full pytest suite passes.
+
+## Kernel Impact
+
+promote_to_kernel

--- a/references/BOOTSTRAP.md
+++ b/references/BOOTSTRAP.md
@@ -55,6 +55,14 @@ The bootstrapped canon should also make explicit:
 - that the minimum Superpowers mapping includes `using-superpowers` for skill selection and `verification-before-completion` before success claims
 - that orchestrated agentic coding has one accountable orchestrator, one worker by default, at most two parallel workers with disjoint write sets, targeted reviewer agents, prompt write-set contracts, same-patch worker thread lifecycle, one-shot reviewers, `thread_disposition`, and a recovery protocol for executor/resource failures such as `Too many open files`
 - that rich-MCP orchestrators should dispatch project-local no-MCP coding workers when custom agents are available, with the global `code_worker_no_mcp` only as fallback
+- that multi-agent production-bound work uses a named release candidate branch
+  or integration branch, exact commit SHA, draft PR, staging verification,
+  production backup when applicable, production smoke checks, PR evidence,
+  merge to `main`, and intentional branch/worktree cleanup
+- that a second agent recovering live runtime must receive or reconstruct the
+  handoff packet before deploying or restarting services
+- that `main` is source of truth only after the verified release candidate is
+  merged, and agents must not deploy from stale, dirty, or detached checkouts
 - that MCP or App connector tooling is preferred for supported structured external-service operations when available and authorized
 - that local `gh` auth and GitHub App connector auth are different identities with separate permissions
 - that GitHub App repository access and permissions are configured in GitHub Installed Apps, not by storing or editing tokens in project files
@@ -85,6 +93,12 @@ Do not treat a compact behavior guideline file as a replacement for the bootstra
 Do not treat Superpowers or another process-skill pack as a replacement for the bootstrapped canon. Skills help the agent choose the right workflow; the project canon remains the source of truth.
 
 Do not treat subagent fan-out as automatically better. Use the orchestrator/worker/reviewer limits in `references/AGENTIC_CODING_ORCHESTRATION.md`; prefer one worker at a time unless independence and executor health are clear.
+
+Do not treat a runtime recovery as permission to deploy the nearest checkout.
+Use `references/MULTI_AGENT_RELEASE_COORDINATION.md`: identify the active
+release candidate, package fixes into an auditable branch/PR, deploy staging
+first, take production backup or restore point when schema/data can change, and
+record evidence before merging to `main`.
 
 When bootstrapping a Codex project, copy or adapt
 `templates/project/.codex/config.toml` and

--- a/references/MULTI_AGENT_RELEASE_COORDINATION.md
+++ b/references/MULTI_AGENT_RELEASE_COORDINATION.md
@@ -1,0 +1,218 @@
+# Multi-Agent Release Coordination
+
+Use this reference when several agents, branches, or worktrees touch one
+production-bound project at the same time.
+
+The goal is to prevent a new agent from "fixing" production by deploying a
+stale checkout, dirty runtime directory, or incomplete branch while another
+agent's already-verified work is still in flight.
+
+## Core Rule
+
+`main` is the source of truth only after the verified integration PR is merged.
+Before that, the source of truth for a live recovery or feature cutover is the
+active release candidate: exact branch, commit SHA, PR, deploy command, runtime
+state, and verification evidence.
+
+Do not deploy from memory, from a detached/dirty directory, or from "whatever is
+currently on main" without checking whether a newer release candidate has
+already been staged or deployed.
+
+## Roles
+
+The orchestrator owns release coordination:
+
+- branch topology and active PRs;
+- which worktree is allowed to deploy;
+- which commit is deployed to staging and production;
+- runtime/schema/env verification;
+- PR comments or closeout evidence;
+- merge and branch cleanup.
+
+Worker agents own only their assigned patch. They do not deploy, mutate live
+databases, send live messages, or make provider-console changes unless an
+active PRD creates a narrow audited role for that exact surface.
+
+If a worker or second agent is asked to recover a live failure, it must first
+return a state report when it does not know the release candidate:
+
+```text
+NEEDS_RELEASE_CONTEXT:
+- repo path / worktree path
+- current branch and commit
+- open PRs or integration branch
+- deployed commit if known
+- runtime health/log symptom
+- deploy script expected by project canon
+```
+
+## Branch Topology
+
+Use one of these shapes.
+
+### Single Slice
+
+```text
+main
+  -> feature-or-fix-branch
+    -> draft PR
+    -> staging
+    -> production when approved
+    -> merge to main
+```
+
+### Multiple Agent Slices
+
+```text
+main
+  -> agent-a-branch
+  -> agent-b-branch
+  -> integration/<release-name>
+    -> draft PR
+    -> staging
+    -> production when approved
+    -> merge to main
+```
+
+The integration branch is a release candidate, not another scratch branch. It
+must be clean, reviewable, and deployed only by the orchestrator or by a
+project-authorized release agent following the documented command.
+
+## Worktree Rules
+
+- Create implementation branches in isolated worktrees.
+- Never switch a dirty shared checkout to "just deploy quickly".
+- Never deploy from a detached checkout unless the project canon explicitly
+  marks that checkout as the release candidate and records its SHA.
+- If a branch is already checked out in another worktree, do not force switch
+  it locally; use that worktree or create a new branch/worktree.
+- Before accepting a worker result or deploying:
+
+```bash
+git status --short --branch
+git diff --check
+git log --oneline --decorate --max-count=5
+```
+
+Git ref/index/worktree-mutating commands remain serialized per repository. Do
+not parallelize fetch, pull, switch, checkout, merge, rebase, branch deletion,
+or push for the same repo.
+
+## Runtime Recovery Protocol
+
+When production is broken, do not start by rebuilding the app from the closest
+directory.
+
+Use this order:
+
+1. Identify the live symptom and current health.
+2. Identify the expected release candidate branch/PR/SHA.
+3. Inspect the runtime deploy directory for dirty or detached state, but do not
+   mutate it.
+4. Check the project deploy/runbook command, including compose overlays,
+   migration mode, env forwarding, and secret boundaries.
+5. Package any recovery change into a branch or integration branch.
+6. Verify locally or in CI as appropriate.
+7. Deploy staging from the exact release candidate SHA.
+8. Run staging smoke checks.
+9. Take a production backup or restore point before schema/data changes.
+10. Deploy production from the same release candidate SHA with the documented
+    production-safe command.
+11. Run read-safe production smoke checks and log scans.
+12. Record evidence in the PR or closeout.
+13. Merge the verified PR to `main`.
+
+If production was hot-fixed from a runtime directory under emergency pressure,
+the next action is to package that exact runtime delta into a normal branch/PR
+and reconcile `main`. Do not leave production ahead of GitHub.
+
+## Deploy Command Contract
+
+Production-bound projects must document the exact deploy command. Agents must
+use the project command instead of inventing a raw shell sequence.
+
+The command contract should name:
+
+- working directory;
+- branch or SHA;
+- build flags;
+- migration mode;
+- compose or service overlays;
+- env file ownership;
+- backup path;
+- health endpoints;
+- rollback path.
+
+For database drift, prefer the narrowest safe schema path. If a broad migration
+or `db push` preview includes destructive or unrelated changes, create a
+focused additive patch and record why the broad path is blocked.
+
+## Handoff Packet Between Agents
+
+When opening or handing off to another agent, include:
+
+```text
+repo:
+  path:
+  source_of_truth_branch:
+  active_worktree:
+  current_release_candidate:
+  exact_commit_sha:
+github:
+  issue_or_pr:
+  draft_or_ready:
+runtime:
+  staging_url:
+  production_url:
+  deploy_command:
+  backup_required:
+allowed_actions:
+  - ...
+forbidden_actions:
+  - no deploy from dirty/detached checkout
+  - no raw compose/service restart unless runbook says so
+  - no broad schema push without preview
+  - no live sends/customer cleanup/provider writes
+verification:
+  local:
+  staging:
+  production_read_safe:
+open_questions:
+  - ...
+```
+
+If this packet is missing and the task touches live runtime, the second agent
+should ask for or reconstruct it before acting.
+
+## Merge And Closeout
+
+A release candidate can be merged only after:
+
+- CI or local verification required by the project is green;
+- staging was verified for production-bound changes;
+- production was verified when the PR was already rolled out before merge;
+- schema/data backup evidence exists when applicable;
+- runtime smoke checks and log scans were recorded;
+- the PR body/comment or closeout says what commit was deployed;
+- the head branch can be deleted or explicitly kept with a reason.
+
+After merge:
+
+- fetch `origin/main`;
+- confirm `origin/main` contains the merge commit;
+- delete the remote release branch when appropriate;
+- keep or remove local worktrees intentionally;
+- treat `main` as source of truth again.
+
+## Red Flags
+
+Stop and recover before changing runtime when any of these are true:
+
+- the checkout is dirty and the dirty files are not fully understood;
+- the checkout is detached and no release candidate SHA was recorded;
+- another agent has an open branch/PR that was already staged or deployed;
+- the deploy command differs from the project runbook;
+- compose/service overlays are ambiguous;
+- schema preview includes destructive or unrelated changes;
+- provider/webhook/runtime env is inferred instead of inspected;
+- a worker wants to deploy or touch live data without explicit authority.

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -143,6 +143,59 @@ ref lock race occurs, recover with sequential `git status --short --branch`,
 the needed `git fetch`, `git pull --ff-only` when appropriate, and `git diff
 --check`.
 
+## Multi-agent release coordination canon
+
+When several agents, branches, or worktrees touch the same production-bound
+project, one orchestrator owns the release candidate.
+
+Rules:
+
+- `main` is source of truth only after the verified PR or integration PR is
+  merged.
+- Before merge, the source of truth is the active release candidate: branch,
+  exact commit SHA, PR, deploy command, runtime state, and verification
+  evidence.
+- Do not recover production by deploying from a stale `main`, dirty checkout,
+  detached runtime directory, or "closest" local folder.
+- Multiple agent branches that must ship together go through an integration
+  branch and draft PR before staging or production.
+- Deploy only from a clean release-candidate worktree and the documented
+  project deploy command.
+- Runtime recovery starts by identifying live health, current deployed state,
+  active PR/branch/SHA, deploy overlays/env, schema state, and logs.
+- Workers do not deploy, mutate live databases, send live messages, or change
+  provider consoles unless an active PRD creates a narrow audited role for that
+  surface.
+- A second agent touching live runtime must receive or reconstruct a handoff
+  packet before acting.
+
+Minimum handoff packet:
+
+```text
+repo path
+source-of-truth branch
+active worktree
+current release candidate branch and SHA
+issue or PR
+staging and production URLs
+documented deploy command
+backup requirement
+allowed actions
+forbidden actions
+verification commands
+open questions
+```
+
+Production-bound closeout records:
+
+- staging deploy and smoke evidence;
+- production backup or restore point when schema/data can change;
+- production deploy command and commit SHA;
+- read-safe production smoke checks;
+- log scan result;
+- PR comment or closeout evidence;
+- merge to `main` and release branch cleanup decision.
+
 ## Research canon
 
 - use Tavily Search first, not Tavily Research first

--- a/tests/test_repo_kernel_canon.py
+++ b/tests/test_repo_kernel_canon.py
@@ -26,6 +26,7 @@ class RepoKernelCanonTests(unittest.TestCase):
             "references/BOOTSTRAP.md",
             "references/BEHAVIORAL_OVERLAY.md",
             "references/AGENTIC_CODING_ORCHESTRATION.md",
+            "references/MULTI_AGENT_RELEASE_COORDINATION.md",
             "references/PROJECT_LOCAL_WORKERS.md",
             "references/SUPERPOWERS_SKILL_ORCHESTRATION.md",
             "references/MCP_TOOLING.md",
@@ -51,6 +52,7 @@ class RepoKernelCanonTests(unittest.TestCase):
         self.assertIn("model_adapter_policy", payload)
         self.assertIn("agent_skill_orchestration_policy", payload)
         self.assertIn("agentic_coding_orchestration_policy", payload)
+        self.assertIn("multi_agent_release_coordination_policy", payload)
         self.assertIn("project_local_worker_policy", payload)
         self.assertIn("mcp_tooling_policy", payload)
         self.assertIn("research_policy", payload)
@@ -146,6 +148,32 @@ class RepoKernelCanonTests(unittest.TestCase):
             "after_git_ref_lock_race_recover_with_sequential_git_status_fetch_pull_ff_only_and_diff_check",
             agentic_policy["recovery_rules"],
         )
+        release_policy = payload["multi_agent_release_coordination_policy"]
+        self.assertIn(
+            "main_is_source_of_truth_only_after_verified_integration_pr_is_merged",
+            release_policy["core_rule"],
+        )
+        self.assertIn(
+            "before_merge_source_of_truth_is_active_release_candidate_branch_sha_pr_deploy_command_runtime_state_and_verification_evidence",
+            release_policy["core_rule"],
+        )
+        self.assertIn("integration_release_branch", release_policy["branch_topologies"]["multiple_agent_slices"])
+        self.assertIn("deployed_commit_by_environment", release_policy["orchestrator_owns"])
+        self.assertIn(
+            "second_agent_touching_live_runtime_receives_or_reconstructs_handoff_packet_before_acting",
+            release_policy["worker_live_runtime_rules"],
+        )
+        self.assertIn("current_release_candidate", release_policy["handoff_packet_required_fields"])
+        self.assertIn(
+            "deploy_production_from_same_release_candidate_sha_with_documented_command",
+            release_policy["runtime_recovery_order"],
+        )
+        self.assertIn("service_or_compose_overlays", release_policy["deploy_command_contract_fields"])
+        self.assertIn(
+            "after_merge_fetch_origin_main_and_confirm_merge_commit",
+            release_policy["closeout_rules"],
+        )
+        self.assertIn("dirty_checkout_with_unexplained_files", release_policy["red_flags"])
         worker_policy = payload["project_local_worker_policy"]
         self.assertEqual(
             worker_policy["preferred_files"]["project_worker"],


### PR DESCRIPTION
## Summary

- Adds a multi-agent release coordination reference for shared project work, integration branches, deploy source-of-truth, handoff packets, and runtime recovery.
- Adds machine-readable policy to ENGINEERING_KERNEL.yaml and project bootstrap/template guidance.
- Updates the kernel skill discovery text, README, OpenAI agent metadata, PRD evidence, and regression tests.

## Verification

- git diff --check
- .venv/bin/python -m unittest tests.test_repo_kernel_canon
- .venv/bin/python -m unittest discover -s tests

## Kernel Impact

promote_to_kernel
