### PR TITLE
docs: guard shared root checkout usage

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -79,6 +79,11 @@ The multi-agent release coordination rule is explicit:
 - `main` is source of truth only after the verified integration PR is merged
 - before merge, the source of truth is the active release candidate branch,
   commit SHA, PR, deploy command, runtime state, and verification evidence
+- the repository's primary/root checkout is a coordination surface, not the
+  default workspace for agent edits; every task uses an isolated worktree unless
+  the handoff explicitly names the root checkout as the active worktree
+- docs-only, PRD-only, and canon-only slices still use isolated worktrees when
+  parallel work exists in the same repository
 - never recover production by deploying from a stale, detached, or dirty
   checkout without first identifying the release candidate
 - multiple agent branches that must ship together go through an integration

--- a/references/AGENTIC_CODING_ORCHESTRATION.md
+++ b/references/AGENTIC_CODING_ORCHESTRATION.md
@@ -195,6 +195,19 @@ misleading local view. If this happens, stop parallel git calls and recover with
 sequential `git status --short --branch`, the needed `git fetch`, `git pull
 --ff-only` when appropriate, and `git diff --check`.
 
+Shared root checkout guard:
+
+- the repository's primary/root checkout is a coordination surface, not a
+  default worker workspace;
+- before any edit, the orchestrator or worker must identify the assigned
+  worktree with `git status --short --branch` and `git worktree list`;
+- if the current checkout is clean `main`, a shared operator checkout, a branch
+  owned by another agent, or has unexplained dirty files, do not edit there;
+- create or reuse an isolated worktree for the slice, including docs-only,
+  PRD-only, and canon-only changes when parallel work exists;
+- if the worktree assignment is unclear, return `NEEDS_WORKTREE_CONTEXT` rather
+  than making a best-effort edit in the current directory.
+
 Worker MCP policy:
 
 - do not rely on the task prompt to disable MCP; MCP startup happens before the

--- a/references/MULTI_AGENT_RELEASE_COORDINATION.md
+++ b/references/MULTI_AGENT_RELEASE_COORDINATION.md
@@ -81,7 +81,20 @@ project-authorized release agent following the documented command.
 ## Worktree Rules
 
 - Create implementation branches in isolated worktrees.
+- Treat the repository's primary/root checkout as a coordination checkout, not
+  an agent workspace. It should stay on clean `main` by default, or be named
+  explicitly in the active handoff as the release-candidate worktree.
+- A new agent must not start edits in the current terminal directory just
+  because it is already there. Before the first edit, it must run
+  `git status --short --branch` and `git worktree list`, identify whether the
+  current checkout is the assigned worktree, and create or switch to a separate
+  worktree when it is not.
+- The isolated-worktree rule applies to docs-only and canon-only slices too
+  when another agent, branch, PR, or release candidate is active for the same
+  repository. Documentation edits can still corrupt another branch's closeout.
 - Never switch a dirty shared checkout to "just deploy quickly".
+- Never switch a shared root checkout away from its current branch to "make
+  room" for a new task. Create another worktree instead.
 - Never deploy from a detached checkout unless the project canon explicitly
   marks that checkout as the release candidate and records its SHA.
 - If a branch is already checked out in another worktree, do not force switch
@@ -156,6 +169,7 @@ repo:
   path:
   source_of_truth_branch:
   active_worktree:
+  shared_root_checkout_policy:
   current_release_candidate:
   exact_commit_sha:
 github:
@@ -184,6 +198,10 @@ open_questions:
 If this packet is missing and the task touches live runtime, the second agent
 should ask for or reconstruct it before acting.
 
+For non-runtime work, a reduced handoff still records the active worktree. If a
+second agent cannot tell whether the current checkout is assigned to its slice,
+it should return `NEEDS_WORKTREE_CONTEXT` instead of editing.
+
 ## Merge And Closeout
 
 A release candidate can be merged only after:
@@ -210,6 +228,8 @@ Stop and recover before changing runtime when any of these are true:
 
 - the checkout is dirty and the dirty files are not fully understood;
 - the checkout is detached and no release candidate SHA was recorded;
+- the current directory is the shared root checkout and the task did not
+  explicitly assign that checkout as the active worktree;
 - another agent has an open branch/PR that was already staged or deployed;
 - the deploy command differs from the project runbook;
 - compose/service overlays are ambiguous;

--- a/templates/project/AGENTS.md
+++ b/templates/project/AGENTS.md
@@ -155,8 +155,18 @@ Rules:
 - Before merge, the source of truth is the active release candidate: branch,
   exact commit SHA, PR, deploy command, runtime state, and verification
   evidence.
+- The repository's primary/root checkout is not a default agent workspace. Keep
+  it clean on `main` or explicitly record it as the active worktree in the
+  handoff. Otherwise every task, including docs-only/canon-only work, uses an
+  isolated worktree.
+- Before the first edit, run `git status --short --branch` and
+  `git worktree list`; if the current checkout belongs to another branch,
+  another agent, or has unexplained dirty files, stop and create/reuse an
+  isolated worktree.
 - Do not recover production by deploying from a stale `main`, dirty checkout,
   detached runtime directory, or "closest" local folder.
+- Do not switch the shared root checkout to a new task branch just to begin
+  work; create a new worktree instead.
 - Multiple agent branches that must ship together go through an integration
   branch and draft PR before staging or production.
 - Deploy only from a clean release-candidate worktree and the documented
@@ -175,6 +185,7 @@ Minimum handoff packet:
 repo path
 source-of-truth branch
 active worktree
+shared root checkout policy
 current release candidate branch and SHA
 issue or PR
 staging and production URLs


### PR DESCRIPTION
Adds a shared root checkout guard to the upstream engineering kernel. The rule makes isolated worktrees the default for agent edits, including docs/PRD/canon slices when parallel work exists, and requires NEEDS_WORKTREE_CONTEXT instead of editing when workspace assignment is unclear. Verification: rg contract checks and git diff --check.